### PR TITLE
fix urls in metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,9 +4,9 @@
   "author": "Dennis Hoppe",
   "summary": "This module installs, configures and manages the Fail2ban service.",
   "license": "Apache 2.0",
-  "source": "git://github.com/dhoppe/fail2ban.git",
-  "project_page": "https://github.com/dhoppe/fail2ban",
-  "issues_url": "https://github.com/dhoppe/fail2ban/issues",
+  "source": "git://github.com/dhoppe/puppet-fail2ban.git",
+  "project_page": "https://github.com/dhoppe/puppet-fail2ban",
+  "issues_url": "https://github.com/dhoppe/puppet-fail2ban/issues",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
The URLs on the forge result in 404s.
This fixes them, but will require a new release to reflect on the forge