### PR TITLE
Added the ability to change ports in the default jails

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,18 @@ suspicious logins. Defaults to "fail2ban@${::domain}".
 
 Determines which services should be protected by Fail2ban. Defaults to '['ssh', 'ssh-ddos']'.
 
+#### `jail_ports`
+
+Hash overwriting the port for the default jails, i.e., if ssh is running in port 1234 
+this would update the jail accordingly without need to modify ssh entry on /etc/services
+
+```puppet
+    class { 'fail2ban':
+      ...
+      jail_ports => {'ssh' => '1234'}
+    }
+```
+
 #### `maxretry`
 
 Determines the number of failed login attempts needed to block a host.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class fail2ban (
   $bantime                  = 432000,
   $email                    = "fail2ban@${::domain}",
   $jails                    = ['ssh', 'ssh-ddos'],
+  $jail_ports               = {},
   $maxretry                 = 3,
   $whitelist                = ['127.0.0.1/8', '192.168.56.0/24'],
   $custom_jails             = undef,
@@ -59,6 +60,7 @@ class fail2ban (
 
   validate_hash($config_file_hash)
   validate_hash($config_file_options_hash)
+  validate_hash($jail_ports)
 
   validate_re($service_ensure, '^(running|stopped)$')
   validate_string($service_name)

--- a/templates/Carbon/etc/fail2ban/jail.conf.erb
+++ b/templates/Carbon/etc/fail2ban/jail.conf.erb
@@ -187,7 +187,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 
 [sshd]
 enabled = <%= scope['::fail2ban::jails'].include? "sshd" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd') ? scope['::fail2ban::jail_ports']['sshd'] : 'ssh' %>
 logpath = %(sshd_log)s
 
 
@@ -196,19 +196,19 @@ logpath = %(sshd_log)s
 # The mail-whois action send a notification e-mail with a whois request
 # in the body.
 enabled = <%= scope['::fail2ban::jails'].include? "sshd-ddos" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd-ddos') ? scope['::fail2ban::jail_ports']['sshd-ddos'] : 'ssh' %>
 logpath = %(sshd_log)s
 
 
 [dropbear]
 enabled = <%= scope['::fail2ban::jails'].include? "dropbear" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('dropbear') ? scope['::fail2ban::jail_ports']['dropbear'] : 'ssh' %>
 logpath  = %(dropbear_log)s
 
 
 [selinux-ssh]
 enabled = <%= scope['::fail2ban::jails'].include? "selinux-ssh" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('selinux-ssh') ? scope['::fail2ban::jail_ports']['selinux-ssh'] : 'ssh' %>
 logpath  = %(auditd_log)s
 maxretry = 5
 
@@ -219,7 +219,7 @@ maxretry = 5
 
 [apache-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-auth') ? scope['::fail2ban::jail_ports']['apache-auth'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 
 
@@ -227,7 +227,7 @@ logpath  = %(apache_error_log)s
 # Ban hosts which agent identifies spammer robots crawling the web
 # for email addresses. The mail outputs are buffered.
 enabled = <%= scope['::fail2ban::jails'].include? "apache-badbots" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-badbots') ? scope['::fail2ban::jail_ports']['apache-badbots'] : 'http,https' %>
 logpath  = %(apache_access_log)s
 bantime  = 172800
 maxretry = 1
@@ -235,35 +235,35 @@ maxretry = 1
 
 [apache-noscript]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-noscript') ? scope['::fail2ban::jail_ports']['apache-noscript'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 6
 
 
 [apache-overflows]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-overflows') ? scope['::fail2ban::jail_ports']['apache-overflows'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-nohome]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-nohome" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-nohome') ? scope['::fail2ban::jail_ports']['apache-nohome'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-botsearch]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-botsearch" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-botsearch') ? scope['::fail2ban::jail_ports']['apache-botsearch'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-fakegooglebot]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-fakegooglebot" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-fakegooglebot') ? scope['::fail2ban::jail_ports']['apache-fakegooglebot'] : 'http,https' %>
 logpath  = %(apache_access_log)s
 maxretry = 1
 ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
@@ -271,24 +271,24 @@ ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
 
 [apache-modsecurity]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-modsecurity" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-modsecurity') ? scope['::fail2ban::jail_ports']['apache-modsecurity'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 [apache-shellshock]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-shellshock" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('apache-shellshock') ? scope['::fail2ban::jail_ports']['apache-shellshock'] : 'http,https' %>
 logpath = %(apache_error_log)s
 maxretry = 1
 
 [nginx-http-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-http-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('nginx-http-auth') ? scope['::fail2ban::jail_ports']['nginx-http-auth'] : 'http,https' %>
 logpath = %(nginx_error_log)s
 
 [nginx-botsearch]
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-botsearch" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('nginx-botsearch') ? scope['::fail2ban::jail_ports']['nginx-botsearch'] : 'http,https' %>
 logpath  = %(nginx_error_log)s
 maxretry = 2
 
@@ -298,14 +298,14 @@ maxretry = 2
 
 [php-url-fopen]
 enabled = <%= scope['::fail2ban::jails'].include? "php-url-fopen" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('php-url-fopen') ? scope['::fail2ban::jail_ports']['php-url-fopen'] : 'http,https' %>
 logpath = %(nginx_access_log)s
           %(apache_access_log)s
 
 
 [suhosin]
 enabled = <%= scope['::fail2ban::jails'].include? "suhosin" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('suhosin') ? scope['::fail2ban::jail_ports']['suhosin'] : 'http,https' %>
 logpath = %(suhosin_log)s
 
 
@@ -313,7 +313,7 @@ logpath = %(suhosin_log)s
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-auth" %>
 # Same as above for Apache's mod_auth
 # It catches wrong authentifications
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('lighttpd-auth') ? scope['::fail2ban::jail_ports']['lighttpd-auth'] : 'http,https' %>
 logpath = %(lighttpd_error_log)s
 
 
@@ -323,25 +323,25 @@ logpath = %(lighttpd_error_log)s
 
 [roundcube-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "roundcube-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('roundcube-auth') ? scope['::fail2ban::jail_ports']['roundcube-auth'] : 'http,https' %>
 logpath  = logpath = %(roundcube_errors_log)s
 
 
 [openwebmail]
 enabled = <%= scope['::fail2ban::jails'].include? "openwebmail" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('openwebmail') ? scope['::fail2ban::jail_ports']['openwebmail'] : 'http,https' %>
 logpath  = /var/log/openwebmail.log
 
 
 [horde]
 enabled = <%= scope['::fail2ban::jails'].include? "horde" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('horde') ? scope['::fail2ban::jail_ports']['horde'] : 'http,https' %>
 logpath  = /var/log/horde/horde.log
 
 
 [groupoffice]
 enabled = <%= scope['::fail2ban::jails'].include? "groupoffice" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('groupoffice') ? scope['::fail2ban::jail_ports']['groupoffice'] : 'http,https' %>
 logpath  = /home/groupoffice/log/info.log
 
 
@@ -350,14 +350,14 @@ enabled = <%= scope['::fail2ban::jails'].include? "sogo-auth" %>
 # Monitor SOGo groupware server
 # without proxy this would be:
 # port    = 20000
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('sogo-auth') ? scope['::fail2ban::jail_ports']['sogo-auth'] : 'http,https' %>
 logpath  = /var/log/sogo/sogo.log
 
 
 [tine20]
 enabled = <%= scope['::fail2ban::jails'].include? "tine20" %>
 logpath  = /var/log/tine20/tine20.log
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('tine20') ? scope['::fail2ban::jail_ports']['tine20'] : 'http,https' %>
 maxretry = 5
 
 
@@ -368,31 +368,31 @@ maxretry = 5
 
 [drupal-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "drupal-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('drupal-auth') ? scope['::fail2ban::jail_ports']['drupal-auth'] : 'http,https' %>
 logpath  = %(syslog_daemon)s
 
 [guacamole]
 enabled = <%= scope['::fail2ban::jails'].include? "guacamole" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('guacamole') ? scope['::fail2ban::jail_ports']['guacamole'] : 'http,https' %>
 logpath  = /var/log/tomcat*/catalina.out
 
 [monit]
 #Ban clients brute-forcing the monit gui login
 enabled = <%= scope['::fail2ban::jails'].include? "monit" %>
 filter   = monit
-port = 2812
+port = <%= scope['::fail2ban::jail_ports'].key?('monit') ? scope['::fail2ban::jail_ports']['monit'] : '2812' %>
 logpath  = /var/log/monit
 
 
 [webmin-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "webmin-auth" %>
-port    = 10000
+port    = <%= scope['::fail2ban::jail_ports'].key?('webmin-auth') ? scope['::fail2ban::jail_ports']['webmin-auth'] : '10000' %>
 logpath = %(syslog_authpriv)s
 
 
 [froxlor-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "froxlor-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('froxlor-auth') ? scope['::fail2ban::jail_ports']['froxlor-auth'] : 'http,https' %>
 logpath  = %(syslog_authpriv)s
 
 
@@ -403,13 +403,13 @@ logpath  = %(syslog_authpriv)s
 
 [squid]
 enabled = <%= scope['::fail2ban::jails'].include? "squid" %>
-port     =  80,443,3128,8080
+port     = <%= scope['::fail2ban::jail_ports'].key?('squid') ? scope['::fail2ban::jail_ports']['squid'] : '80,443,3128,8080' %>
 logpath = /var/log/squid/access.log
 
 
 [3proxy]
 enabled = <%= scope['::fail2ban::jails'].include? "3proxy" %>
-port    = 3128
+port    = <%= scope['::fail2ban::jail_ports'].key?('3proxy') ? scope['::fail2ban::jail_ports']['3proxy'] : '3128' %>
 logpath = /var/log/3proxy.log
 
 
@@ -420,27 +420,27 @@ logpath = /var/log/3proxy.log
 
 [proftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "proftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('proftpd') ? scope['::fail2ban::jail_ports']['proftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(proftpd_log)s
 
 
 [pure-ftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('pure-ftpd') ? scope['::fail2ban::jail_ports']['pure-ftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(pureftpd_log)s
 maxretry = 6
 
 
 [gssftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "gssftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('gssftpd') ? scope['::fail2ban::jail_ports']['gssftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(syslog_daemon)s
 maxretry = 6
 
 
 [wuftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('wuftpd') ? scope['::fail2ban::jail_ports']['wuftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(wuftpd_log)s
 maxretry = 6
 
@@ -451,7 +451,7 @@ maxretry = 6
 # if you want to rely on PAM failed login attempts
 # vsftpd's failregex should match both of those formats
 enabled = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('vsftpd') ? scope['::fail2ban::jail_ports']['vsftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(vsftpd_log)s
 
 
@@ -462,45 +462,45 @@ logpath  = %(vsftpd_log)s
 # ASSP SMTP Proxy Jail
 [assp]
 enabled = <%= scope['::fail2ban::jails'].include? "assp" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('assp') ? scope['::fail2ban::jail_ports']['assp'] : 'smtp,465,submission' %>
 logpath  = /root/path/to/assp/logs/maillog.txt
 
 
 [courier-smtp]
 enabled = <%= scope['::fail2ban::jails'].include? "courier-smtp" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-smtp') ? scope['::fail2ban::jail_ports']['courier-smtp'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 
 
 [postfix]
 enabled = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix') ? scope['::fail2ban::jail_ports']['postfix'] : 'smtp,465,submission' %>
 logpath  = %(postfix_log)s
 
 
 [postfix-rbl]
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix-rbl" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-rbl') ? scope['::fail2ban::jail_ports']['postfix-rbl'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 maxretry = 1
 
 
 [sendmail-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "sendmail-auth" %>
-port    = submission,465,smtp
+port    = <%= scope['::fail2ban::jail_ports'].key?('sendmail-auth') ? scope['::fail2ban::jail_ports']['sendmail-auth'] : 'smtp,465,submission' %>
 logpath = %(syslog_mail)s
 
 
 [sendmail-reject]
 enabled = <%= scope['::fail2ban::jails'].include? "sendmail-reject" %>
-port     = smtp,465,submission
+port    = <%= scope['::fail2ban::jail_ports'].key?('sendmail-reject') ? scope['::fail2ban::jail_ports']['sendmail-reject'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 
 
 [qmail-rbl]
 enabled = <%= scope['::fail2ban::jails'].include? "qmail-rbl" %>
 filter  = qmail
-port    = smtp,465,submission
+port    = <%= scope['::fail2ban::jail_ports'].key?('qmail-rbl') ? scope['::fail2ban::jail_ports']['qmail-rbl'] : 'smtp,465,submission' %>
 logpath = /service/qmail/log/main/current
 
 
@@ -508,37 +508,37 @@ logpath = /service/qmail/log/main/current
 # but can be set by syslog_facility in the dovecot configuration.
 [dovecot]
 enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
-port    = pop3,pop3s,imap,imaps,submission,465,sieve
+port    = <%= scope['::fail2ban::jail_ports'].key?('dovecot') ? scope['::fail2ban::jail_ports']['dovecot'] : 'pop3,pop3s,imap,imaps,submission,465,sieve' %>
 logpath = %(dovecot_log)s
 
 
 [sieve]
 enabled = <%= scope['::fail2ban::jails'].include? "sieve" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('sieve') ? scope['::fail2ban::jail_ports']['sieve'] : 'smtp,465,submission' %>
 logpath = %(dovecot_log)s
 
 
 [solid-pop3d]
 enabled = <%= scope['::fail2ban::jails'].include? "solid-pop3d" %>
-port    = pop3,pop3s
+port    = <%= scope['::fail2ban::jail_ports'].key?('solid-pop3d') ? scope['::fail2ban::jail_ports']['solid-pop3d'] : 'pop3,pop3s' %>
 logpath = %(solidpop3d_log)s
 
 
 [exim]
 enabled = <%= scope['::fail2ban::jails'].include? "exim" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('exim') ? scope['::fail2ban::jail_ports']['exim'] : 'smtp,465,submission' %>
 logpath = %(exim_main_log)s
 
 
 [exim-spam]
 enabled = <%= scope['::fail2ban::jails'].include? "exim-spam" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('exim-spam') ? scope['::fail2ban::jail_ports']['exim-spam'] : 'smtp,465,submission' %>
 logpath = %(exim_main_log)s
 
 
 [kerio]
 enabled = <%= scope['::fail2ban::jails'].include? "kerio" %>
-port    = imap,smtp,imaps,465
+port    = <%= scope['::fail2ban::jail_ports'].key?('kerio') ? scope['::fail2ban::jail_ports']['kerio'] : 'imap,smtp,imaps,465' %>
 logpath = /opt/kerio/mailserver/store/logs/security.log
 
 
@@ -549,13 +549,13 @@ logpath = /opt/kerio/mailserver/store/logs/security.log
 
 [courier-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "courier-auth" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-auth') ? scope['::fail2ban::jail_ports']['courier-auth'] : 'smtp,465,submission,imap3,imaps,pop3,pop3s' %>
 logpath  = %(syslog_mail)s
 
 
 [postfix-sasl]
 enabled = <%= scope['::fail2ban::jails'].include? "postfix-sasl" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-sasl') ? scope['::fail2ban::jail_ports']['postfix-sasl'] : 'smtp,465,submission,imap3,imaps,pop3,pop3s' %>
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
 # "warn" level but overall at the smaller filesize.
@@ -564,25 +564,25 @@ logpath  = %(postfix_log)s
 
 [perdition]
 enabled = <%= scope['::fail2ban::jails'].include? "perdition" %>
-port   = imap3,imaps,pop3,pop3s
+port   = <%= scope['::fail2ban::jail_ports'].key?('perdition') ? scope['::fail2ban::jail_ports']['perdition'] : 'imap3,imaps,pop3,pop3s' %>
 logpath = %(syslog_mail)s
 
 
 [squirrelmail]
 enabled = <%= scope['::fail2ban::jails'].include? "squierrelmail" %>
-port = smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks
+port = <%= scope['::fail2ban::jail_ports'].key?('squirrelmail') ? scope['::fail2ban::jail_ports']['squirrelmail'] : 'smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks' %>
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 
 [cyrus-imap]
 enabled = <%= scope['::fail2ban::jails'].include? "cyrus-imap" %>
-port   = imap3,imaps
+port   = <%= scope['::fail2ban::jail_ports'].key?('cyrus-imap') ? scope['::fail2ban::jail_ports']['cyrus-imap'] : 'imap3,imaps' %>
 logpath = %(syslog_mail)s
 
 
 [uwimap-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "uwimap-auth" %>
-port   = imap3,imaps
+port   = <%= scope['::fail2ban::jail_ports'].key?('uwimap-auth') ? scope['::fail2ban::jail_ports']['uwimap-auth'] : 'imap3,imaps' %>
 logpath = %(syslog_mail)s
 
 
@@ -614,13 +614,13 @@ logpath = %(syslog_mail)s
 
 [named-refused]
 enabled = <%= scope['::fail2ban::jails'].include? "named-refused" %>
-port     = domain,953
+port     = <%= scope['::fail2ban::jail_ports'].key?('named-refused') ? scope['::fail2ban::jail_ports']['named-refused'] : 'domain,953' %>
 logpath  = /var/log/named/security.log
 
 
 [nsd]
 enabled = <%= scope['::fail2ban::jails'].include? "nsd" %>
-port     = 53
+port     = <%= scope['::fail2ban::jail_ports'].key?('nsd') ? scope['::fail2ban::jail_ports']['nsd'] : '53' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
 logpath = /var/log/nsd.log
@@ -632,7 +632,7 @@ logpath = /var/log/nsd.log
 
 [asterisk]
 enabled = <%= scope['::fail2ban::jails'].include? "asterisk" %>
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('asterisk') ? scope['::fail2ban::jail_ports']['asterisk'] : '5060,5061' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
@@ -642,7 +642,7 @@ maxretry = 10
 
 [freeswitch]
 enabled = <%= scope['::fail2ban::jails'].include? "freeswitch" %>
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('freeswitch') ? scope['::fail2ban::jail_ports']['freeswitch'] : '5060,5061' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
@@ -663,7 +663,7 @@ maxretry = 10
 # log-error=/var/log/mysqld.log
 [mysqld-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "mysqld-auth" %>
-port     = 3306
+port     = <%= scope['::fail2ban::jail_ports'].key?('mysqld-auth') ? scope['::fail2ban::jail_ports']['mysqld-auth'] : '3306' %>
 logpath  = %(mysql_log)s
 maxretry = 5
 
@@ -709,7 +709,7 @@ logpath = /var/log/stunnel4/stunnel.log
 
 [ejabberd-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "ejabberd-auth" %>
-port    = 5222
+port    = <%= scope['::fail2ban::jail_ports'].key?('ejabberd-auth') ? scope['::fail2ban::jail_ports']['ejabberd-auth'] : '5222' %>
 logpath = /var/log/ejabberd/ejabberd.log
 
 
@@ -717,7 +717,8 @@ logpath = /var/log/ejabberd/ejabberd.log
 enabled = <%= scope['::fail2ban::jails'].include? "counter-strike" %>
 logpath = /opt/cstrike/logs/L[0-9]*.log
 # Firewall: http://www.cstrike-planet.com/faq/6
-tcpport = 27030,27031,27032,27033,27034,27035,27036,27037,27038,27039
+# CAUTION: variable jail_ports would only ban TCP ports
+tcpport = <%= scope['::fail2ban::jail_ports'].key?('counter-strike') ? scope['::fail2ban::jail_ports']['counter-strike'] : '27030,27031,27032,27033,27034,27035,27036,27037,27038,27039' %>
 udpport = 1200,27000,27001,27002,27003,27004,27005,27006,27007,27008,27009,27010,27011,27012,27013,27014,27015
 action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
@@ -740,7 +741,7 @@ banaction = iptables-allports
 [directadmin]
 enabled = <%= scope['::fail2ban::jails'].include? "directadmin" %>
 logpath = /var/log/directadmin/login.log
-port = 2222
+port = <%= scope['::fail2ban::jail_ports'].key?('directadmin') ? scope['::fail2ban::jail_ports']['directadmin'] : '2222' %>
 
 [portsentry]
 enabled  = <%= scope['::fail2ban::jails'].include? "portsentry" %>
@@ -750,7 +751,7 @@ maxretry = 1
 [pass2allow-ftp]
 # this pass2allow example allows FTP traffic after successful HTTP authentication
 enabled      = <%= scope['::fail2ban::jails'].include? "pass2allow-ftp" %>
-port         = ftp,ftp-data,ftps,ftps-data
+port         = <%= scope['::fail2ban::jail_ports'].key?('pass2allow-ftp') ? scope['::fail2ban::jail_ports']['pass2allow-ftp'] : 'ftp,ftp-data,ftps,ftps-data' %>
 # knocking_url variable must be overridden to some secret value in filter.d/apache-pass.local
 filter       = apache-pass
 # access log of the website with HTTP auth

--- a/templates/Core/etc/fail2ban/jail.conf.erb
+++ b/templates/Core/etc/fail2ban/jail.conf.erb
@@ -227,7 +227,7 @@ logpath  = %(apache_error_log)s
 # Ban hosts which agent identifies spammer robots crawling the web
 # for email addresses. The mail outputs are buffered.
 enabled = <%= scope['::fail2ban::jails'].include? "apache-badbots" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-badbots') ? scope['::fail2ban::jail_ports']['apache-badbots'] : 'http,https' %>
 logpath  = %(apache_access_log)s
 bantime  = 172800
 maxretry = 1
@@ -235,35 +235,35 @@ maxretry = 1
 
 [apache-noscript]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-noscript') ? scope['::fail2ban::jail_ports']['apache-noscript'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 6
 
 
 [apache-overflows]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-overflows') ? scope['::fail2ban::jail_ports']['apache-overflows'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-nohome]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-nohome" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-nohome') ? scope['::fail2ban::jail_ports']['apache-nohome'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-botsearch]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-botsearch" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-botsearch') ? scope['::fail2ban::jail_ports']['apache-botsearch'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-fakegooglebot]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-fakegooglebot" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-fakegooglebot') ? scope['::fail2ban::jail_ports']['apache-fakegooglebot'] : 'http,https' %>
 logpath  = %(apache_access_log)s
 maxretry = 1
 ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
@@ -271,24 +271,24 @@ ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
 
 [apache-modsecurity]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-modsecurity" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-modsecurity') ? scope['::fail2ban::jail_ports']['apache-modsecurity'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 [apache-shellshock]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-shellshock" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('apache-shellshock') ? scope['::fail2ban::jail_ports']['apache-shellshock'] : 'http,https' %>
 logpath = %(apache_error_log)s
 maxretry = 1
 
 [nginx-http-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-http-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('nginx-http-auth') ? scope['::fail2ban::jail_ports']['nginx-http-auth'] : 'http,https' %>
 logpath = %(nginx_error_log)s
 
 [nginx-botsearch]
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-botsearch" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('nginx-botsearch') ? scope['::fail2ban::jail_ports']['nginx-botsearch'] : 'http,https' %>
 logpath  = %(nginx_error_log)s
 maxretry = 2
 
@@ -298,14 +298,14 @@ maxretry = 2
 
 [php-url-fopen]
 enabled = <%= scope['::fail2ban::jails'].include? "php-url-fopen" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('php-url-fopen') ? scope['::fail2ban::jail_ports']['php-url-fopen'] : 'http,https' %>
 logpath = %(nginx_access_log)s
           %(apache_access_log)s
 
 
 [suhosin]
 enabled = <%= scope['::fail2ban::jails'].include? "suhosin" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('suhosin') ? scope['::fail2ban::jail_ports']['suhosin'] : 'http,https' %>
 logpath = %(suhosin_log)s
 
 
@@ -313,7 +313,7 @@ logpath = %(suhosin_log)s
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-auth" %>
 # Same as above for Apache's mod_auth
 # It catches wrong authentifications
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('lighttpd-auth') ? scope['::fail2ban::jail_ports']['lighttpd-auth'] : 'http,https' %>
 logpath = %(lighttpd_error_log)s
 
 
@@ -323,25 +323,25 @@ logpath = %(lighttpd_error_log)s
 
 [roundcube-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "roundcube-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('roundcube-auth') ? scope['::fail2ban::jail_ports']['roundcube-auth'] : 'http,https' %>
 logpath  = logpath = %(roundcube_errors_log)s
 
 
 [openwebmail]
 enabled = <%= scope['::fail2ban::jails'].include? "openwebmail" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('openwebmail') ? scope['::fail2ban::jail_ports']['openwebmail'] : 'http,https' %>
 logpath  = /var/log/openwebmail.log
 
 
 [horde]
 enabled = <%= scope['::fail2ban::jails'].include? "horde" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('horde') ? scope['::fail2ban::jail_ports']['horde'] : 'http,https' %>
 logpath  = /var/log/horde/horde.log
 
 
 [groupoffice]
 enabled = <%= scope['::fail2ban::jails'].include? "groupoffice" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('groupoffice') ? scope['::fail2ban::jail_ports']['groupoffice'] : 'http,https' %>
 logpath  = /home/groupoffice/log/info.log
 
 
@@ -350,14 +350,14 @@ enabled = <%= scope['::fail2ban::jails'].include? "sogo-auth" %>
 # Monitor SOGo groupware server
 # without proxy this would be:
 # port    = 20000
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('sogo-auth') ? scope['::fail2ban::jail_ports']['sogo-auth'] : 'http,https' %>
 logpath  = /var/log/sogo/sogo.log
 
 
 [tine20]
 enabled = <%= scope['::fail2ban::jails'].include? "tine20" %>
 logpath  = /var/log/tine20/tine20.log
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('tine20') ? scope['::fail2ban::jail_ports']['tine20'] : 'http,https' %>
 maxretry = 5
 
 
@@ -368,12 +368,12 @@ maxretry = 5
 
 [drupal-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "drupal-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('drupal-auth') ? scope['::fail2ban::jail_ports']['drupal-auth'] : 'http,https' %>
 logpath  = %(syslog_daemon)s
 
 [guacamole]
 enabled = <%= scope['::fail2ban::jails'].include? "guacamole" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('guacamole') ? scope['::fail2ban::jail_ports']['guacamole'] : 'http,https' %>
 logpath  = /var/log/tomcat*/catalina.out
 
 [monit]
@@ -392,7 +392,7 @@ logpath = %(syslog_authpriv)s
 
 [froxlor-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "froxlor-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('froxlor-auth') ? scope['::fail2ban::jail_ports']['froxlor-auth'] : 'http,https' %>
 logpath  = %(syslog_authpriv)s
 
 

--- a/templates/Core/etc/fail2ban/jail.conf.erb
+++ b/templates/Core/etc/fail2ban/jail.conf.erb
@@ -219,7 +219,7 @@ maxretry = 5
 
 [apache-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-auth') ? scope['::fail2ban::jail_ports']['apache-auth'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 
 
@@ -380,13 +380,13 @@ logpath  = /var/log/tomcat*/catalina.out
 #Ban clients brute-forcing the monit gui login
 enabled = <%= scope['::fail2ban::jails'].include? "monit" %>
 filter   = monit
-port = 2812
+port = <%= scope['::fail2ban::jail_ports'].key?('monit') ? scope['::fail2ban::jail_ports']['monit'] : '2812' %>
 logpath  = /var/log/monit
 
 
 [webmin-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "webmin-auth" %>
-port    = 10000
+port    = <%= scope['::fail2ban::jail_ports'].key?('webmin-auth') ? scope['::fail2ban::jail_ports']['webmin-auth'] : '10000' %>
 logpath = %(syslog_authpriv)s
 
 
@@ -403,13 +403,13 @@ logpath  = %(syslog_authpriv)s
 
 [squid]
 enabled = <%= scope['::fail2ban::jails'].include? "squid" %>
-port     =  80,443,3128,8080
+port     = <%= scope['::fail2ban::jail_ports'].key?('squid') ? scope['::fail2ban::jail_ports']['squid'] : '80,443,3128,8080' %>
 logpath = /var/log/squid/access.log
 
 
 [3proxy]
 enabled = <%= scope['::fail2ban::jails'].include? "3proxy" %>
-port    = 3128
+port    = <%= scope['::fail2ban::jail_ports'].key?('3proxy') ? scope['::fail2ban::jail_ports']['3proxy'] : '3128' %>
 logpath = /var/log/3proxy.log
 
 
@@ -420,27 +420,27 @@ logpath = /var/log/3proxy.log
 
 [proftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "proftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('proftpd') ? scope['::fail2ban::jail_ports']['proftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(proftpd_log)s
 
 
 [pure-ftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('pure-ftpd') ? scope['::fail2ban::jail_ports']['pure-ftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(pureftpd_log)s
 maxretry = 6
 
 
 [gssftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "gssftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('gssftpd') ? scope['::fail2ban::jail_ports']['gssftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(syslog_daemon)s
 maxretry = 6
 
 
 [wuftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('wuftpd') ? scope['::fail2ban::jail_ports']['wuftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(wuftpd_log)s
 maxretry = 6
 
@@ -451,7 +451,7 @@ maxretry = 6
 # if you want to rely on PAM failed login attempts
 # vsftpd's failregex should match both of those formats
 enabled = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('vsftpd') ? scope['::fail2ban::jail_ports']['vsftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(vsftpd_log)s
 
 
@@ -462,45 +462,45 @@ logpath  = %(vsftpd_log)s
 # ASSP SMTP Proxy Jail
 [assp]
 enabled = <%= scope['::fail2ban::jails'].include? "assp" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('assp') ? scope['::fail2ban::jail_ports']['assp'] : 'smtp,465,submission' %>
 logpath  = /root/path/to/assp/logs/maillog.txt
 
 
 [courier-smtp]
 enabled = <%= scope['::fail2ban::jails'].include? "courier-smtp" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-smtp') ? scope['::fail2ban::jail_ports']['courier-smtp'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 
 
 [postfix]
 enabled = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix') ? scope['::fail2ban::jail_ports']['postfix'] : 'smtp,465,submission' %>
 logpath  = %(postfix_log)s
 
 
 [postfix-rbl]
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix-rbl" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-rbl') ? scope['::fail2ban::jail_ports']['postfix-rbl'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 maxretry = 1
 
 
 [sendmail-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "sendmail-auth" %>
-port    = submission,465,smtp
+port    = <%= scope['::fail2ban::jail_ports'].key?('sendmail-auth') ? scope['::fail2ban::jail_ports']['sendmail-auth'] : 'smtp,465,submission' %>
 logpath = %(syslog_mail)s
 
 
 [sendmail-reject]
 enabled = <%= scope['::fail2ban::jails'].include? "sendmail-reject" %>
-port     = smtp,465,submission
+port    = <%= scope['::fail2ban::jail_ports'].key?('sendmail-reject') ? scope['::fail2ban::jail_ports']['sendmail-reject'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 
 
 [qmail-rbl]
 enabled = <%= scope['::fail2ban::jails'].include? "qmail-rbl" %>
 filter  = qmail
-port    = smtp,465,submission
+port    = <%= scope['::fail2ban::jail_ports'].key?('qmail-rbl') ? scope['::fail2ban::jail_ports']['qmail-rbl'] : 'smtp,465,submission' %>
 logpath = /service/qmail/log/main/current
 
 
@@ -508,37 +508,37 @@ logpath = /service/qmail/log/main/current
 # but can be set by syslog_facility in the dovecot configuration.
 [dovecot]
 enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
-port    = pop3,pop3s,imap,imaps,submission,465,sieve
+port    = <%= scope['::fail2ban::jail_ports'].key?('dovecot') ? scope['::fail2ban::jail_ports']['dovecot'] : 'pop3,pop3s,imap,imaps,submission,465,sieve' %>
 logpath = %(dovecot_log)s
 
 
 [sieve]
 enabled = <%= scope['::fail2ban::jails'].include? "sieve" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('sieve') ? scope['::fail2ban::jail_ports']['sieve'] : 'smtp,465,submission' %>
 logpath = %(dovecot_log)s
 
 
 [solid-pop3d]
 enabled = <%= scope['::fail2ban::jails'].include? "solid-pop3d" %>
-port    = pop3,pop3s
+port    = <%= scope['::fail2ban::jail_ports'].key?('solid-pop3d') ? scope['::fail2ban::jail_ports']['solid-pop3d'] : 'pop3,pop3s' %>
 logpath = %(solidpop3d_log)s
 
 
 [exim]
 enabled = <%= scope['::fail2ban::jails'].include? "exim" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('exim') ? scope['::fail2ban::jail_ports']['exim'] : 'smtp,465,submission' %>
 logpath = %(exim_main_log)s
 
 
 [exim-spam]
 enabled = <%= scope['::fail2ban::jails'].include? "exim-spam" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('exim-spam') ? scope['::fail2ban::jail_ports']['exim-spam'] : 'smtp,465,submission' %>
 logpath = %(exim_main_log)s
 
 
 [kerio]
 enabled = <%= scope['::fail2ban::jails'].include? "kerio" %>
-port    = imap,smtp,imaps,465
+port    = <%= scope['::fail2ban::jail_ports'].key?('kerio') ? scope['::fail2ban::jail_ports']['kerio'] : 'imap,smtp,imaps,465' %>
 logpath = /opt/kerio/mailserver/store/logs/security.log
 
 
@@ -549,13 +549,13 @@ logpath = /opt/kerio/mailserver/store/logs/security.log
 
 [courier-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "courier-auth" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-auth') ? scope['::fail2ban::jail_ports']['courier-auth'] : 'smtp,465,submission,imap3,imaps,pop3,pop3s' %>
 logpath  = %(syslog_mail)s
 
 
 [postfix-sasl]
 enabled = <%= scope['::fail2ban::jails'].include? "postfix-sasl" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-sasl') ? scope['::fail2ban::jail_ports']['postfix-sasl'] : 'smtp,465,submission,imap3,imaps,pop3,pop3s' %>
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
 # "warn" level but overall at the smaller filesize.
@@ -564,25 +564,25 @@ logpath  = %(postfix_log)s
 
 [perdition]
 enabled = <%= scope['::fail2ban::jails'].include? "perdition" %>
-port   = imap3,imaps,pop3,pop3s
+port   = <%= scope['::fail2ban::jail_ports'].key?('perdition') ? scope['::fail2ban::jail_ports']['perdition'] : 'imap3,imaps,pop3,pop3s' %>
 logpath = %(syslog_mail)s
 
 
 [squirrelmail]
 enabled = <%= scope['::fail2ban::jails'].include? "squierrelmail" %>
-port = smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks
+port = <%= scope['::fail2ban::jail_ports'].key?('squirrelmail') ? scope['::fail2ban::jail_ports']['squirrelmail'] : 'smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks' %>
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 
 [cyrus-imap]
 enabled = <%= scope['::fail2ban::jails'].include? "cyrus-imap" %>
-port   = imap3,imaps
+port   = <%= scope['::fail2ban::jail_ports'].key?('cyrus-imap') ? scope['::fail2ban::jail_ports']['cyrus-imap'] : 'imap3,imaps' %>
 logpath = %(syslog_mail)s
 
 
 [uwimap-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "uwimap-auth" %>
-port   = imap3,imaps
+port   = <%= scope['::fail2ban::jail_ports'].key?('uwimap-auth') ? scope['::fail2ban::jail_ports']['uwimap-auth'] : 'imap3,imaps' %>
 logpath = %(syslog_mail)s
 
 
@@ -614,13 +614,13 @@ logpath = %(syslog_mail)s
 
 [named-refused]
 enabled = <%= scope['::fail2ban::jails'].include? "named-refused" %>
-port     = domain,953
+port     = <%= scope['::fail2ban::jail_ports'].key?('named-refused') ? scope['::fail2ban::jail_ports']['named-refused'] : 'domain,953' %>
 logpath  = /var/log/named/security.log
 
 
 [nsd]
 enabled = <%= scope['::fail2ban::jails'].include? "nsd" %>
-port     = 53
+port     = <%= scope['::fail2ban::jail_ports'].key?('nsd') ? scope['::fail2ban::jail_ports']['nsd'] : '53' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
 logpath = /var/log/nsd.log
@@ -632,7 +632,7 @@ logpath = /var/log/nsd.log
 
 [asterisk]
 enabled = <%= scope['::fail2ban::jails'].include? "asterisk" %>
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('asterisk') ? scope['::fail2ban::jail_ports']['asterisk'] : '5060,5061' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
@@ -642,7 +642,7 @@ maxretry = 10
 
 [freeswitch]
 enabled = <%= scope['::fail2ban::jails'].include? "freeswitch" %>
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('freeswitch') ? scope['::fail2ban::jail_ports']['freeswitch'] : '5060,5061' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
@@ -663,7 +663,7 @@ maxretry = 10
 # log-error=/var/log/mysqld.log
 [mysqld-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "mysqld-auth" %>
-port     = 3306
+port     = <%= scope['::fail2ban::jail_ports'].key?('mysqld-auth') ? scope['::fail2ban::jail_ports']['mysqld-auth'] : '3306' %>
 logpath  = %(mysql_log)s
 maxretry = 5
 
@@ -709,7 +709,7 @@ logpath = /var/log/stunnel4/stunnel.log
 
 [ejabberd-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "ejabberd-auth" %>
-port    = 5222
+port    = <%= scope['::fail2ban::jail_ports'].key?('ejabberd-auth') ? scope['::fail2ban::jail_ports']['ejabberd-auth'] : '5222' %>
 logpath = /var/log/ejabberd/ejabberd.log
 
 
@@ -717,7 +717,8 @@ logpath = /var/log/ejabberd/ejabberd.log
 enabled = <%= scope['::fail2ban::jails'].include? "counter-strike" %>
 logpath = /opt/cstrike/logs/L[0-9]*.log
 # Firewall: http://www.cstrike-planet.com/faq/6
-tcpport = 27030,27031,27032,27033,27034,27035,27036,27037,27038,27039
+# CAUTION: variable jail_ports would only ban TCP ports
+tcpport = <%= scope['::fail2ban::jail_ports'].key?('counter-strike') ? scope['::fail2ban::jail_ports']['counter-strike'] : '27030,27031,27032,27033,27034,27035,27036,27037,27038,27039' %>
 udpport = 1200,27000,27001,27002,27003,27004,27005,27006,27007,27008,27009,27010,27011,27012,27013,27014,27015
 action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
@@ -740,7 +741,7 @@ banaction = iptables-allports
 [directadmin]
 enabled = <%= scope['::fail2ban::jails'].include? "directadmin" %>
 logpath = /var/log/directadmin/login.log
-port = 2222
+port = <%= scope['::fail2ban::jail_ports'].key?('directadmin') ? scope['::fail2ban::jail_ports']['directadmin'] : '2222' %>
 
 [portsentry]
 enabled  = <%= scope['::fail2ban::jails'].include? "portsentry" %>
@@ -750,7 +751,7 @@ maxretry = 1
 [pass2allow-ftp]
 # this pass2allow example allows FTP traffic after successful HTTP authentication
 enabled      = <%= scope['::fail2ban::jails'].include? "pass2allow-ftp" %>
-port         = ftp,ftp-data,ftps,ftps-data
+port         = <%= scope['::fail2ban::jail_ports'].key?('pass2allow-ftp') ? scope['::fail2ban::jail_ports']['pass2allow-ftp'] : 'ftp,ftp-data,ftps,ftps-data' %>
 # knocking_url variable must be overridden to some secret value in filter.d/apache-pass.local
 filter       = apache-pass
 # access log of the website with HTTP auth

--- a/templates/Core/etc/fail2ban/jail.conf.erb
+++ b/templates/Core/etc/fail2ban/jail.conf.erb
@@ -187,7 +187,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 
 [sshd]
 enabled = <%= scope['::fail2ban::jails'].include? "sshd" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd') ? scope['::fail2ban::jail_ports']['sshd'] : 'ssh' %>
 logpath = %(sshd_log)s
 
 
@@ -196,19 +196,19 @@ logpath = %(sshd_log)s
 # The mail-whois action send a notification e-mail with a whois request
 # in the body.
 enabled = <%= scope['::fail2ban::jails'].include? "sshd-ddos" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd-ddos') ? scope['::fail2ban::jail_ports']['sshd-ddos'] : 'ssh' %>
 logpath = %(sshd_log)s
 
 
 [dropbear]
 enabled = <%= scope['::fail2ban::jails'].include? "dropbear" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('dropbear') ? scope['::fail2ban::jail_ports']['dropbear'] : 'ssh' %>
 logpath  = %(dropbear_log)s
 
 
 [selinux-ssh]
 enabled = <%= scope['::fail2ban::jails'].include? "selinux-ssh" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('selinux-ssh') ? scope['::fail2ban::jail_ports']['selinux-ssh'] : 'ssh' %>
 logpath  = %(auditd_log)s
 maxretry = 5
 

--- a/templates/Final/etc/fail2ban/jail.conf.erb
+++ b/templates/Final/etc/fail2ban/jail.conf.erb
@@ -187,7 +187,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 
 [sshd]
 enabled = <%= scope['::fail2ban::jails'].include? "sshd" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd') ? scope['::fail2ban::jail_ports']['sshd'] : 'ssh' %>
 logpath = %(sshd_log)s
 
 
@@ -196,19 +196,19 @@ logpath = %(sshd_log)s
 # The mail-whois action send a notification e-mail with a whois request
 # in the body.
 enabled = <%= scope['::fail2ban::jails'].include? "sshd-ddos" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd-ddos') ? scope['::fail2ban::jail_ports']['sshd-ddos'] : 'ssh' %>
 logpath = %(sshd_log)s
 
 
 [dropbear]
 enabled = <%= scope['::fail2ban::jails'].include? "dropbear" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('dropbear') ? scope['::fail2ban::jail_ports']['dropbear'] : 'ssh' %>
 logpath  = %(dropbear_log)s
 
 
 [selinux-ssh]
 enabled = <%= scope['::fail2ban::jails'].include? "selinux-ssh" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('selinux-ssh') ? scope['::fail2ban::jail_ports']['selinux-ssh'] : 'ssh' %>
 logpath  = %(auditd_log)s
 maxretry = 5
 
@@ -219,7 +219,7 @@ maxretry = 5
 
 [apache-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-auth') ? scope['::fail2ban::jail_ports']['apache-auth'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 
 
@@ -227,7 +227,7 @@ logpath  = %(apache_error_log)s
 # Ban hosts which agent identifies spammer robots crawling the web
 # for email addresses. The mail outputs are buffered.
 enabled = <%= scope['::fail2ban::jails'].include? "apache-badbots" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-badbots') ? scope['::fail2ban::jail_ports']['apache-badbots'] : 'http,https' %>
 logpath  = %(apache_access_log)s
 bantime  = 172800
 maxretry = 1
@@ -235,35 +235,35 @@ maxretry = 1
 
 [apache-noscript]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-noscript') ? scope['::fail2ban::jail_ports']['apache-noscript'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 6
 
 
 [apache-overflows]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-overflows') ? scope['::fail2ban::jail_ports']['apache-overflows'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-nohome]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-nohome" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-nohome') ? scope['::fail2ban::jail_ports']['apache-nohome'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-botsearch]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-botsearch" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-botsearch') ? scope['::fail2ban::jail_ports']['apache-botsearch'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-fakegooglebot]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-fakegooglebot" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-fakegooglebot') ? scope['::fail2ban::jail_ports']['apache-fakegooglebot'] : 'http,https' %>
 logpath  = %(apache_access_log)s
 maxretry = 1
 ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
@@ -271,24 +271,24 @@ ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
 
 [apache-modsecurity]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-modsecurity" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-modsecurity') ? scope['::fail2ban::jail_ports']['apache-modsecurity'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 [apache-shellshock]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-shellshock" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('apache-shellshock') ? scope['::fail2ban::jail_ports']['apache-shellshock'] : 'http,https' %>
 logpath = %(apache_error_log)s
 maxretry = 1
 
 [nginx-http-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-http-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('nginx-http-auth') ? scope['::fail2ban::jail_ports']['nginx-http-auth'] : 'http,https' %>
 logpath = %(nginx_error_log)s
 
 [nginx-botsearch]
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-botsearch" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('nginx-botsearch') ? scope['::fail2ban::jail_ports']['nginx-botsearch'] : 'http,https' %>
 logpath  = %(nginx_error_log)s
 maxretry = 2
 
@@ -298,14 +298,14 @@ maxretry = 2
 
 [php-url-fopen]
 enabled = <%= scope['::fail2ban::jails'].include? "php-url-fopen" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('php-url-fopen') ? scope['::fail2ban::jail_ports']['php-url-fopen'] : 'http,https' %>
 logpath = %(nginx_access_log)s
           %(apache_access_log)s
 
 
 [suhosin]
 enabled = <%= scope['::fail2ban::jails'].include? "suhosin" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('suhosin') ? scope['::fail2ban::jail_ports']['suhosin'] : 'http,https' %>
 logpath = %(suhosin_log)s
 
 
@@ -313,7 +313,7 @@ logpath = %(suhosin_log)s
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-auth" %>
 # Same as above for Apache's mod_auth
 # It catches wrong authentifications
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('lighttpd-auth') ? scope['::fail2ban::jail_ports']['lighttpd-auth'] : 'http,https' %>
 logpath = %(lighttpd_error_log)s
 
 
@@ -323,25 +323,25 @@ logpath = %(lighttpd_error_log)s
 
 [roundcube-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "roundcube-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('roundcube-auth') ? scope['::fail2ban::jail_ports']['roundcube-auth'] : 'http,https' %>
 logpath  = logpath = %(roundcube_errors_log)s
 
 
 [openwebmail]
 enabled = <%= scope['::fail2ban::jails'].include? "openwebmail" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('openwebmail') ? scope['::fail2ban::jail_ports']['openwebmail'] : 'http,https' %>
 logpath  = /var/log/openwebmail.log
 
 
 [horde]
 enabled = <%= scope['::fail2ban::jails'].include? "horde" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('horde') ? scope['::fail2ban::jail_ports']['horde'] : 'http,https' %>
 logpath  = /var/log/horde/horde.log
 
 
 [groupoffice]
 enabled = <%= scope['::fail2ban::jails'].include? "groupoffice" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('groupoffice') ? scope['::fail2ban::jail_ports']['groupoffice'] : 'http,https' %>
 logpath  = /home/groupoffice/log/info.log
 
 
@@ -350,14 +350,14 @@ enabled = <%= scope['::fail2ban::jails'].include? "sogo-auth" %>
 # Monitor SOGo groupware server
 # without proxy this would be:
 # port    = 20000
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('sogo-auth') ? scope['::fail2ban::jail_ports']['sogo-auth'] : 'http,https' %>
 logpath  = /var/log/sogo/sogo.log
 
 
 [tine20]
 enabled = <%= scope['::fail2ban::jails'].include? "tine20" %>
 logpath  = /var/log/tine20/tine20.log
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('tine20') ? scope['::fail2ban::jail_ports']['tine20'] : 'http,https' %>
 maxretry = 5
 
 
@@ -368,31 +368,31 @@ maxretry = 5
 
 [drupal-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "drupal-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('drupal-auth') ? scope['::fail2ban::jail_ports']['drupal-auth'] : 'http,https' %>
 logpath  = %(syslog_daemon)s
 
 [guacamole]
 enabled = <%= scope['::fail2ban::jails'].include? "guacamole" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('guacamole') ? scope['::fail2ban::jail_ports']['guacamole'] : 'http,https' %>
 logpath  = /var/log/tomcat*/catalina.out
 
 [monit]
 #Ban clients brute-forcing the monit gui login
 enabled = <%= scope['::fail2ban::jails'].include? "monit" %>
 filter   = monit
-port = 2812
+port = <%= scope['::fail2ban::jail_ports'].key?('monit') ? scope['::fail2ban::jail_ports']['monit'] : '2812' %>
 logpath  = /var/log/monit
 
 
 [webmin-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "webmin-auth" %>
-port    = 10000
+port    = <%= scope['::fail2ban::jail_ports'].key?('webmin-auth') ? scope['::fail2ban::jail_ports']['webmin-auth'] : '10000' %>
 logpath = %(syslog_authpriv)s
 
 
 [froxlor-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "froxlor-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('froxlor-auth') ? scope['::fail2ban::jail_ports']['froxlor-auth'] : 'http,https' %>
 logpath  = %(syslog_authpriv)s
 
 
@@ -403,13 +403,13 @@ logpath  = %(syslog_authpriv)s
 
 [squid]
 enabled = <%= scope['::fail2ban::jails'].include? "squid" %>
-port     =  80,443,3128,8080
+port     = <%= scope['::fail2ban::jail_ports'].key?('squid') ? scope['::fail2ban::jail_ports']['squid'] : '80,443,3128,8080' %>
 logpath = /var/log/squid/access.log
 
 
 [3proxy]
 enabled = <%= scope['::fail2ban::jails'].include? "3proxy" %>
-port    = 3128
+port    = <%= scope['::fail2ban::jail_ports'].key?('3proxy') ? scope['::fail2ban::jail_ports']['3proxy'] : '3128' %>
 logpath = /var/log/3proxy.log
 
 
@@ -420,27 +420,27 @@ logpath = /var/log/3proxy.log
 
 [proftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "proftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('proftpd') ? scope['::fail2ban::jail_ports']['proftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(proftpd_log)s
 
 
 [pure-ftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('pure-ftpd') ? scope['::fail2ban::jail_ports']['pure-ftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(pureftpd_log)s
 maxretry = 6
 
 
 [gssftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "gssftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('gssftpd') ? scope['::fail2ban::jail_ports']['gssftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(syslog_daemon)s
 maxretry = 6
 
 
 [wuftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('wuftpd') ? scope['::fail2ban::jail_ports']['wuftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(wuftpd_log)s
 maxretry = 6
 
@@ -451,7 +451,7 @@ maxretry = 6
 # if you want to rely on PAM failed login attempts
 # vsftpd's failregex should match both of those formats
 enabled = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('vsftpd') ? scope['::fail2ban::jail_ports']['vsftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(vsftpd_log)s
 
 
@@ -462,45 +462,45 @@ logpath  = %(vsftpd_log)s
 # ASSP SMTP Proxy Jail
 [assp]
 enabled = <%= scope['::fail2ban::jails'].include? "assp" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('assp') ? scope['::fail2ban::jail_ports']['assp'] : 'smtp,465,submission' %>
 logpath  = /root/path/to/assp/logs/maillog.txt
 
 
 [courier-smtp]
 enabled = <%= scope['::fail2ban::jails'].include? "courier-smtp" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-smtp') ? scope['::fail2ban::jail_ports']['courier-smtp'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 
 
 [postfix]
 enabled = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix') ? scope['::fail2ban::jail_ports']['postfix'] : 'smtp,465,submission' %>
 logpath  = %(postfix_log)s
 
 
 [postfix-rbl]
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix-rbl" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-rbl') ? scope['::fail2ban::jail_ports']['postfix-rbl'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 maxretry = 1
 
 
 [sendmail-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "sendmail-auth" %>
-port    = submission,465,smtp
+port    = <%= scope['::fail2ban::jail_ports'].key?('sendmail-auth') ? scope['::fail2ban::jail_ports']['sendmail-auth'] : 'smtp,465,submission' %>
 logpath = %(syslog_mail)s
 
 
 [sendmail-reject]
 enabled = <%= scope['::fail2ban::jails'].include? "sendmail-reject" %>
-port     = smtp,465,submission
+port    = <%= scope['::fail2ban::jail_ports'].key?('sendmail-reject') ? scope['::fail2ban::jail_ports']['sendmail-reject'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 
 
 [qmail-rbl]
 enabled = <%= scope['::fail2ban::jails'].include? "qmail-rbl" %>
 filter  = qmail
-port    = smtp,465,submission
+port    = <%= scope['::fail2ban::jail_ports'].key?('qmail-rbl') ? scope['::fail2ban::jail_ports']['qmail-rbl'] : 'smtp,465,submission' %>
 logpath = /service/qmail/log/main/current
 
 
@@ -508,37 +508,37 @@ logpath = /service/qmail/log/main/current
 # but can be set by syslog_facility in the dovecot configuration.
 [dovecot]
 enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
-port    = pop3,pop3s,imap,imaps,submission,465,sieve
+port    = <%= scope['::fail2ban::jail_ports'].key?('dovecot') ? scope['::fail2ban::jail_ports']['dovecot'] : 'pop3,pop3s,imap,imaps,submission,465,sieve' %>
 logpath = %(dovecot_log)s
 
 
 [sieve]
 enabled = <%= scope['::fail2ban::jails'].include? "sieve" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('sieve') ? scope['::fail2ban::jail_ports']['sieve'] : 'smtp,465,submission' %>
 logpath = %(dovecot_log)s
 
 
 [solid-pop3d]
 enabled = <%= scope['::fail2ban::jails'].include? "solid-pop3d" %>
-port    = pop3,pop3s
+port    = <%= scope['::fail2ban::jail_ports'].key?('solid-pop3d') ? scope['::fail2ban::jail_ports']['solid-pop3d'] : 'pop3,pop3s' %>
 logpath = %(solidpop3d_log)s
 
 
 [exim]
 enabled = <%= scope['::fail2ban::jails'].include? "exim" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('exim') ? scope['::fail2ban::jail_ports']['exim'] : 'smtp,465,submission' %>
 logpath = %(exim_main_log)s
 
 
 [exim-spam]
 enabled = <%= scope['::fail2ban::jails'].include? "exim-spam" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('exim-spam') ? scope['::fail2ban::jail_ports']['exim-spam'] : 'smtp,465,submission' %>
 logpath = %(exim_main_log)s
 
 
 [kerio]
 enabled = <%= scope['::fail2ban::jails'].include? "kerio" %>
-port    = imap,smtp,imaps,465
+port    = <%= scope['::fail2ban::jail_ports'].key?('kerio') ? scope['::fail2ban::jail_ports']['kerio'] : 'imap,smtp,imaps,465' %>
 logpath = /opt/kerio/mailserver/store/logs/security.log
 
 
@@ -549,13 +549,13 @@ logpath = /opt/kerio/mailserver/store/logs/security.log
 
 [courier-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "courier-auth" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-auth') ? scope['::fail2ban::jail_ports']['courier-auth'] : 'smtp,465,submission,imap3,imaps,pop3,pop3s' %>
 logpath  = %(syslog_mail)s
 
 
 [postfix-sasl]
 enabled = <%= scope['::fail2ban::jails'].include? "postfix-sasl" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-sasl') ? scope['::fail2ban::jail_ports']['postfix-sasl'] : 'smtp,465,submission,imap3,imaps,pop3,pop3s' %>
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
 # "warn" level but overall at the smaller filesize.
@@ -564,25 +564,25 @@ logpath  = %(postfix_log)s
 
 [perdition]
 enabled = <%= scope['::fail2ban::jails'].include? "perdition" %>
-port   = imap3,imaps,pop3,pop3s
+port   = <%= scope['::fail2ban::jail_ports'].key?('perdition') ? scope['::fail2ban::jail_ports']['perdition'] : 'imap3,imaps,pop3,pop3s' %>
 logpath = %(syslog_mail)s
 
 
 [squirrelmail]
 enabled = <%= scope['::fail2ban::jails'].include? "squierrelmail" %>
-port = smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks
+port = <%= scope['::fail2ban::jail_ports'].key?('squirrelmail') ? scope['::fail2ban::jail_ports']['squirrelmail'] : 'smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks' %>
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 
 [cyrus-imap]
 enabled = <%= scope['::fail2ban::jails'].include? "cyrus-imap" %>
-port   = imap3,imaps
+port   = <%= scope['::fail2ban::jail_ports'].key?('cyrus-imap') ? scope['::fail2ban::jail_ports']['cyrus-imap'] : 'imap3,imaps' %>
 logpath = %(syslog_mail)s
 
 
 [uwimap-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "uwimap-auth" %>
-port   = imap3,imaps
+port   = <%= scope['::fail2ban::jail_ports'].key?('uwimap-auth') ? scope['::fail2ban::jail_ports']['uwimap-auth'] : 'imap3,imaps' %>
 logpath = %(syslog_mail)s
 
 
@@ -614,13 +614,13 @@ logpath = %(syslog_mail)s
 
 [named-refused]
 enabled = <%= scope['::fail2ban::jails'].include? "named-refused" %>
-port     = domain,953
+port     = <%= scope['::fail2ban::jail_ports'].key?('named-refused') ? scope['::fail2ban::jail_ports']['named-refused'] : 'domain,953' %>
 logpath  = /var/log/named/security.log
 
 
 [nsd]
 enabled = <%= scope['::fail2ban::jails'].include? "nsd" %>
-port     = 53
+port     = <%= scope['::fail2ban::jail_ports'].key?('nsd') ? scope['::fail2ban::jail_ports']['nsd'] : '53' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
 logpath = /var/log/nsd.log
@@ -632,7 +632,7 @@ logpath = /var/log/nsd.log
 
 [asterisk]
 enabled = <%= scope['::fail2ban::jails'].include? "asterisk" %>
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('asterisk') ? scope['::fail2ban::jail_ports']['asterisk'] : '5060,5061' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
@@ -642,7 +642,7 @@ maxretry = 10
 
 [freeswitch]
 enabled = <%= scope['::fail2ban::jails'].include? "freeswitch" %>
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('freeswitch') ? scope['::fail2ban::jail_ports']['freeswitch'] : '5060,5061' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
@@ -663,7 +663,7 @@ maxretry = 10
 # log-error=/var/log/mysqld.log
 [mysqld-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "mysqld-auth" %>
-port     = 3306
+port     = <%= scope['::fail2ban::jail_ports'].key?('mysqld-auth') ? scope['::fail2ban::jail_ports']['mysqld-auth'] : '3306' %>
 logpath  = %(mysql_log)s
 maxretry = 5
 
@@ -709,7 +709,7 @@ logpath = /var/log/stunnel4/stunnel.log
 
 [ejabberd-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "ejabberd-auth" %>
-port    = 5222
+port    = <%= scope['::fail2ban::jail_ports'].key?('ejabberd-auth') ? scope['::fail2ban::jail_ports']['ejabberd-auth'] : '5222' %>
 logpath = /var/log/ejabberd/ejabberd.log
 
 
@@ -717,7 +717,8 @@ logpath = /var/log/ejabberd/ejabberd.log
 enabled = <%= scope['::fail2ban::jails'].include? "counter-strike" %>
 logpath = /opt/cstrike/logs/L[0-9]*.log
 # Firewall: http://www.cstrike-planet.com/faq/6
-tcpport = 27030,27031,27032,27033,27034,27035,27036,27037,27038,27039
+# CAUTION: variable jail_ports would only ban TCP ports
+tcpport = <%= scope['::fail2ban::jail_ports'].key?('counter-strike') ? scope['::fail2ban::jail_ports']['counter-strike'] : '27030,27031,27032,27033,27034,27035,27036,27037,27038,27039' %>
 udpport = 1200,27000,27001,27002,27003,27004,27005,27006,27007,27008,27009,27010,27011,27012,27013,27014,27015
 action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
@@ -740,7 +741,7 @@ banaction = iptables-allports
 [directadmin]
 enabled = <%= scope['::fail2ban::jails'].include? "directadmin" %>
 logpath = /var/log/directadmin/login.log
-port = 2222
+port = <%= scope['::fail2ban::jail_ports'].key?('directadmin') ? scope['::fail2ban::jail_ports']['directadmin'] : '2222' %>
 
 [portsentry]
 enabled  = <%= scope['::fail2ban::jails'].include? "portsentry" %>
@@ -750,7 +751,7 @@ maxretry = 1
 [pass2allow-ftp]
 # this pass2allow example allows FTP traffic after successful HTTP authentication
 enabled      = <%= scope['::fail2ban::jails'].include? "pass2allow-ftp" %>
-port         = ftp,ftp-data,ftps,ftps-data
+port         = <%= scope['::fail2ban::jail_ports'].key?('pass2allow-ftp') ? scope['::fail2ban::jail_ports']['pass2allow-ftp'] : 'ftp,ftp-data,ftps,ftps-data' %>
 # knocking_url variable must be overridden to some secret value in filter.d/apache-pass.local
 filter       = apache-pass
 # access log of the website with HTTP auth

--- a/templates/Maipo/etc/fail2ban/jail.conf.erb
+++ b/templates/Maipo/etc/fail2ban/jail.conf.erb
@@ -217,7 +217,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 
 [sshd]
 enabled = <%= scope['::fail2ban::jails'].include? "ssh" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd') ? scope['::fail2ban::jail_ports']['sshd'] : 'ssh' %>
 filter  = sshd
 logpath = %(sshd_log)s
 
@@ -227,13 +227,14 @@ logpath = %(sshd_log)s
 # The mail-whois action send a notification e-mail with a whois request
 # in the boidy.
 enabled = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd-ddos') ? scope['::fail2ban::jail_ports']['sshd-ddos'] : 'ssh' %>
 filter  = sshd
 logpath = %(sshd_log)s
 
 
 [dropbear]
 enabled = <%= scope['::fail2ban::jails'].include? "dropbear" %>
+port    = <%= scope['::fail2ban::jail_ports'].key?('dropbear') ? scope['::fail2ban::jail_ports']['dropbear'] : 'ssh' %>
 port     = ssh
 filter   = sshd
 logpath  = %(dropbear_log)s
@@ -241,7 +242,7 @@ logpath  = %(dropbear_log)s
 
 [selinux-ssh]
 enabled = <%= scope['::fail2ban::jails'].include? "selinux-ssh" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('selinux-ssh') ? scope['::fail2ban::jail_ports']['selinux-ssh'] : 'ssh' %>
 filter   = sshd
 logpath  = %(auditd_log)s
 maxretry = 5
@@ -253,7 +254,7 @@ maxretry = 5
 
 [apache-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-auth') ? scope['::fail2ban::jail_ports']['apache-auth'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 
 
@@ -261,7 +262,7 @@ logpath  = %(apache_error_log)s
 # Ban hosts which agent identifies spammer robots crawling the web
 # for email addresses. The mail outputs are buffered.
 # enabled = <%= scope['::fail2ban::jails'].include? "apache-badbots" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-badbots') ? scope['::fail2ban::jail_ports']['apache-badbots'] : 'http,https' %>
 logpath  = %(apache_access_log)s
 bantime  = 172800
 maxretry = 1
@@ -269,35 +270,35 @@ maxretry = 1
 
 [apache-noscript]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-noscript') ? scope['::fail2ban::jail_ports']['apache-noscript'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 6
 
 
 [apache-overflows]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-overflows') ? scope['::fail2ban::jail_ports']['apache-overflows'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-nohome]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-nohome" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-nohome') ? scope['::fail2ban::jail_ports']['apache-nohome'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-botsearch]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-botsearch" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-botsearch') ? scope['::fail2ban::jail_ports']['apache-botsearch'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-fakegooglebot]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-fakegooglebot" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-fakegooglebot') ? scope['::fail2ban::jail_ports']['apache-fakegooglebot'] : 'http,https' %>
 logpath  = %(apache_access_log)s
 maxretry = 1
 ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
@@ -305,24 +306,24 @@ ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
 
 [apache-modsecurity]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-modsecurity" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-modsecurity') ? scope['::fail2ban::jail_ports']['apache-modsecurity'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 [apache-shellshock]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-shellshock" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('apache-shellshock') ? scope['::fail2ban::jail_ports']['apache-shellshock'] : 'http,https' %>
 logpath = %(apache_error_log)s
 maxretry = 1
 
 [nginx-http-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-http-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('nginx-http-auth') ? scope['::fail2ban::jail_ports']['nginx-http-auth'] : 'http,https' %>
 logpath = %(nginx_error_log)s
 
 [nginx-botsearch]
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-botsearch" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('nginx-botsearch') ? scope['::fail2ban::jail_ports']['nginx-botsearch'] : 'http,https' %>
 logpath  = %(nginx_error_log)s
 maxretry = 2
 
@@ -332,14 +333,14 @@ maxretry = 2
 
 [php-url-fopen]
 enabled = <%= scope['::fail2ban::jails'].include? "php-url-fopen" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('php-url-fopen') ? scope['::fail2ban::jail_ports']['php-url-fopen'] : 'http,https' %>
 logpath = %(nginx_access_log)s
           %(apache_access_log)s
 
 
 [suhosin]
 enabled = <%= scope['::fail2ban::jails'].include? "suhosin" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('suhosin') ? scope['::fail2ban::jail_ports']['suhosin'] : 'http,https' %>
 logpath = %(suhosin_log)s
 
 
@@ -347,7 +348,7 @@ logpath = %(suhosin_log)s
 # Same as above for Apache's mod_auth
 # It catches wrong authentifications
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('lighttpd-auth') ? scope['::fail2ban::jail_ports']['lighttpd-auth'] : 'http,https' %>
 logpath = %(lighttpd_error_log)s
 
 
@@ -357,25 +358,25 @@ logpath = %(lighttpd_error_log)s
 
 [roundcube-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "roundcube-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('roundcube-auth') ? scope['::fail2ban::jail_ports']['roundcube-auth'] : 'http,https' %>
 logpath  = /var/log/roundcube/userlogins
 
 
 [openwebmail]
 enabled = <%= scope['::fail2ban::jails'].include? "openwebmail" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('openwebmail') ? scope['::fail2ban::jail_ports']['openwebmail'] : 'http,https' %>
 logpath  = /var/log/openwebmail.log
 
 
 [horde]
 enabled = <%= scope['::fail2ban::jails'].include? "horde" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('horde') ? scope['::fail2ban::jail_ports']['horde'] : 'http,https' %>
 logpath  = /var/log/horde/horde.log
 
 
 [groupoffice]
 enabled = <%= scope['::fail2ban::jails'].include? "groupoffice" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('groupoffice') ? scope['::fail2ban::jail_ports']['groupoffice'] : 'http,https' %>
 logpath  = /home/groupoffice/log/info.log
 
 
@@ -384,14 +385,14 @@ logpath  = /home/groupoffice/log/info.log
 # without proxy this would be:
 # port    = 20000
 enabled = <%= scope['::fail2ban::jails'].include? "sogo-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('sogo-auth') ? scope['::fail2ban::jail_ports']['sogo-auth'] : 'http,https' %>
 logpath  = /var/log/sogo/sogo.log
 
 
 [tine20]
 enabled = <%= scope['::fail2ban::jails'].include? "tine20" %>
 logpath  = /var/log/tine20/tine20.log
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('tine20') ? scope['::fail2ban::jail_ports']['tine20'] : 'http,https' %>
 maxretry = 5
 
 
@@ -402,25 +403,25 @@ maxretry = 5
 
 [drupal-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "drupal-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('drupal-auth') ? scope['::fail2ban::jail_ports']['drupal-auth'] : 'http,https' %>
 logpath  = %(syslog_daemon)s
 
 [guacamole]
 enabled = <%= scope['::fail2ban::jails'].include? "guacamole" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('guacamole') ? scope['::fail2ban::jail_ports']['guacamole'] : 'http,https' %>
 logpath  = /var/log/tomcat*/catalina.out
 
 [monit]
 #Ban clients brute-forcing the monit gui login
 enabled = <%= scope['::fail2ban::jails'].include? "monit" %>
 filter   = monit
-port = 2812
+port = <%= scope['::fail2ban::jail_ports'].key?('monit') ? scope['::fail2ban::jail_ports']['monit'] : '2812' %>
 logpath  = /var/log/monit
 
 
 [webmin-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "webmin-auth" %>
-port    = 10000
+port    = <%= scope['::fail2ban::jail_ports'].key?('webmin-auth') ? scope['::fail2ban::jail_ports']['webmin-auth'] : '10000' %>
 logpath = %(syslog_authpriv)s
 
 
@@ -431,13 +432,13 @@ logpath = %(syslog_authpriv)s
 
 [squid]
 enabled = <%= scope['::fail2ban::jails'].include? "squid" %>
-port     =  80,443,3128,8080
+port     = <%= scope['::fail2ban::jail_ports'].key?('squid') ? scope['::fail2ban::jail_ports']['squid'] : '80,443,3128,8080' %>
 logpath = /var/log/squid/access.log
 
 
 [3proxy]
 enabled = <%= scope['::fail2ban::jails'].include? "3proxy" %>
-port    = 3128
+port    = <%= scope['::fail2ban::jail_ports'].key?('3proxy') ? scope['::fail2ban::jail_ports']['3proxy'] : '3128' %>
 logpath = /var/log/3proxy.log
 
 #
@@ -447,27 +448,27 @@ logpath = /var/log/3proxy.log
 
 [proftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "proftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('proftpd') ? scope['::fail2ban::jail_ports']['proftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(proftpd_log)s
 
 
 [pure-ftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('pure-ftpd') ? scope['::fail2ban::jail_ports']['pure-ftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(pureftpd_log)s
 maxretry = 6
 
 
 [gssftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "gssftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('gssftpd') ? scope['::fail2ban::jail_ports']['gssftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(syslog_daemon)s
 maxretry = 6
 
 
 [wuftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('wuftpd') ? scope['::fail2ban::jail_ports']['wuftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(wuftpd_log)s
 maxretry = 6
 
@@ -478,7 +479,7 @@ maxretry = 6
 # if you want to rely on PAM failed login attempts
 # vsftpd's failregex should match both of those formats
 enabled = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('vsftpd') ? scope['::fail2ban::jail_ports']['vsftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(vsftpd_log)s
 
 
@@ -489,45 +490,45 @@ logpath  = %(vsftpd_log)s
 # ASSP SMTP Proxy Jail
 [assp]
 enabled = <%= scope['::fail2ban::jails'].include? "assp" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('assp') ? scope['::fail2ban::jail_ports']['assp'] : 'smtp,465,submission' %>
 logpath  = /root/path/to/assp/logs/maillog.txt
 
 
 [courier-smtp]
 enabled = <%= scope['::fail2ban::jails'].include? "courier-smtp" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-smtp') ? scope['::fail2ban::jail_ports']['courier-smtp'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 
 
 [postfix]
 enabled = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix') ? scope['::fail2ban::jail_ports']['postfix'] : 'smtp,465,submission' %>
 logpath  = %(postfix_log)s
 
 
 [postfix-rbl]
 enabled = <%= scope['::fail2ban::jails'].include? "postfix-rbl" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-rbl') ? scope['::fail2ban::jail_ports']['postfix-rbl'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 maxretry = 1
 
 
 [sendmail-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "sendmail-auth" %>
-port    = submission,465,smtp
+port    = <%= scope['::fail2ban::jail_ports'].key?('sendmail-auth') ? scope['::fail2ban::jail_ports']['sendmail-auth'] : 'smtp,465,submission' %>
 logpath = %(syslog_mail)s
 
 
 [sendmail-reject]
 enabled = <%= scope['::fail2ban::jails'].include? "sendmail-reject" %>
-port     = smtp,465,submission
+port    = <%= scope['::fail2ban::jail_ports'].key?('sendmail-reject') ? scope['::fail2ban::jail_ports']['sendmail-reject'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 
 
 [qmail-rbl]
 enabled = <%= scope['::fail2ban::jails'].include? "qmail-rbl" %>
 filter  = qmail
-port    = smtp,465,submission
+port    = <%= scope['::fail2ban::jail_ports'].key?('qmail-rbl') ? scope['::fail2ban::jail_ports']['qmail-rbl'] : 'smtp,465,submission' %>
 logpath = /service/qmail/log/main/current
 
 
@@ -535,37 +536,37 @@ logpath = /service/qmail/log/main/current
 # but can be set by syslog_facility in the dovecot configuration.
 [dovecot]
 enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
-port    = pop3,pop3s,imap,imaps,submission,465,sieve
+port    = <%= scope['::fail2ban::jail_ports'].key?('dovecot') ? scope['::fail2ban::jail_ports']['dovecot'] : 'pop3,pop3s,imap,imaps,submission,465,sieve' %>
 logpath = %(dovecot_log)s
 
 
 [sieve]
 enabled = <%= scope['::fail2ban::jails'].include? "sieve" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('sieve') ? scope['::fail2ban::jail_ports']['sieve'] : 'smtp,465,submission' %>
 logpath = %(dovecot_log)s
 
 
 [solid-pop3d]
 enabled = <%= scope['::fail2ban::jails'].include? "solid-pop3d" %>
-port    = pop3,pop3s
+port    = <%= scope['::fail2ban::jail_ports'].key?('solid-pop3d') ? scope['::fail2ban::jail_ports']['solid-pop3d'] : 'pop3,pop3s' %>
 logpath = %(solidpop3d_log)s
 
 
 [exim]
 enabled = <%= scope['::fail2ban::jails'].include? "exim" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('exim') ? scope['::fail2ban::jail_ports']['exim'] : 'smtp,465,submission' %>
 logpath = %(exim_main_log)s
 
 
 [exim-spam]
 enabled = <%= scope['::fail2ban::jails'].include? "exim-spam" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('exim-spam') ? scope['::fail2ban::jail_ports']['exim-spam'] : 'smtp,465,submission' %>
 logpath = %(exim_main_log)s
 
 
 [kerio]
 enabled = <%= scope['::fail2ban::jails'].include? "kerio" %>
-port    = imap,smtp,imaps,465
+port    = <%= scope['::fail2ban::jail_ports'].key?('kerio') ? scope['::fail2ban::jail_ports']['kerio'] : 'imap,smtp,imaps,465' %>
 logpath = /opt/kerio/mailserver/store/logs/security.log
 
 
@@ -576,13 +577,13 @@ logpath = /opt/kerio/mailserver/store/logs/security.log
 
 [courier-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "courier-auth" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-auth') ? scope['::fail2ban::jail_ports']['courier-auth'] : 'smtp,465,submission,imap3,imaps,pop3,pop3s' %>
 logpath  = %(syslog_mail)s
 
 
 [postfix-sasl]
 enabled = <%= scope['::fail2ban::jails'].include? "postfix-sasl" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-sasl') ? scope['::fail2ban::jail_ports']['postfix-sasl'] : 'smtp,465,submission,imap3,imaps,pop3,pop3s' %>
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
 # "warn" level but overall at the smaller filesize.
@@ -591,25 +592,25 @@ logpath  = %(postfix_log)s
 
 [perdition]
 enabled = <%= scope['::fail2ban::jails'].include? "perdition" %>
-port   = imap3,imaps,pop3,pop3s
+port   = <%= scope['::fail2ban::jail_ports'].key?('perdition') ? scope['::fail2ban::jail_ports']['perdition'] : 'imap3,imaps,pop3,pop3s' %>
 logpath = %(syslog_mail)s
 
 
 [squirrelmail]
 enabled = <%= scope['::fail2ban::jails'].include? "squirrelmail" %>
-port = smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks
+port = <%= scope['::fail2ban::jail_ports'].key?('squirrelmail') ? scope['::fail2ban::jail_ports']['squirrelmail'] : 'smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks' %>
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 
 [cyrus-imap]
 enabled = <%= scope['::fail2ban::jails'].include? "cyrus-imap" %>
-port   = imap3,imaps
+port   = <%= scope['::fail2ban::jail_ports'].key?('cyrus-imap') ? scope['::fail2ban::jail_ports']['cyrus-imap'] : 'imap3,imaps' %>
 logpath = %(syslog_mail)s
 
 
 [uwimap-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "uwimap-auth" %>
-port   = imap3,imaps
+port   = <%= scope['::fail2ban::jail_ports'].key?('uwimap-auth') ? scope['::fail2ban::jail_ports']['uwimap-auth'] : 'imap3,imaps' %>
 logpath = %(syslog_mail)s
 
 
@@ -641,13 +642,13 @@ logpath = %(syslog_mail)s
 
 [named-refused]
 enabled = <%= scope['::fail2ban::jails'].include? "named-refused" %>
-port     = domain,953
+port     = <%= scope['::fail2ban::jail_ports'].key?('named-refused') ? scope['::fail2ban::jail_ports']['named-refused'] : 'domain,953' %>
 logpath  = /var/log/named/security.log
 
 
 [nsd]
 enabled = <%= scope['::fail2ban::jails'].include? "nsd" %>
-port     = 53
+port     = <%= scope['::fail2ban::jail_ports'].key?('nsd') ? scope['::fail2ban::jail_ports']['nsd'] : '53' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
 logpath = /var/log/nsd.log
@@ -659,7 +660,7 @@ logpath = /var/log/nsd.log
 
 [asterisk]
 enabled = <%= scope['::fail2ban::jails'].include? "asterisk" %>
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('asterisk') ? scope['::fail2ban::jail_ports']['asterisk'] : '5060,5061' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
@@ -669,7 +670,7 @@ maxretry = 10
 
 [freeswitch]
 enabled = <%= scope['::fail2ban::jails'].include? "freeswitch" %>
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('freeswitch') ? scope['::fail2ban::jail_ports']['freeswitch'] : '5060,5061' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
@@ -690,7 +691,7 @@ maxretry = 10
 # log-error=/var/log/mysqld.log
 [mysqld-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "mysqld-auth" %>
-port     = 3306
+port     = <%= scope['::fail2ban::jail_ports'].key?('mysqld-auth') ? scope['::fail2ban::jail_ports']['mysqld-auth'] : '3306' %>
 logpath  = %(mysql_log)s
 maxretry = 5
 
@@ -744,7 +745,8 @@ logpath = /var/log/ejabberd/ejabberd.log
 enabled = <%= scope['::fail2ban::jails'].include? "counter-strike" %>
 logpath = /opt/cstrike/logs/L[0-9]*.log
 # Firewall: http://www.cstrike-planet.com/faq/6
-tcpport = 27030,27031,27032,27033,27034,27035,27036,27037,27038,27039
+# CAUTION: variable jail_ports would only ban TCP ports
+tcpport = <%= scope['::fail2ban::jail_ports'].key?('counter-strike') ? scope['::fail2ban::jail_ports']['counter-strike'] : '27030,27031,27032,27033,27034,27035 ,27036,27037,27038,27039' %>
 udpport = 1200,27000,27001,27002,27003,27004,27005,27006,27007,27008,27009,27010,27011,27012,27013,27014,27015
 action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
@@ -767,7 +769,7 @@ banaction = iptables-allports
 [directadmin]
 enabled = <%= scope['::fail2ban::jails'].include? "directadmin" %>
 logpath = /var/log/directadmin/login.log
-port = 2222
+port = <%= scope['::fail2ban::jail_ports'].key?('directadmin') ? scope['::fail2ban::jail_ports']['directadmin'] : '2222' %>
 
 [portsentry]
 enabled = <%= scope['::fail2ban::jails'].include? "portsentry" %>

--- a/templates/Santiago/etc/fail2ban/jail.conf.erb
+++ b/templates/Santiago/etc/fail2ban/jail.conf.erb
@@ -217,7 +217,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 
 [sshd]
 enabled = <%= scope['::fail2ban::jails'].include? "ssh" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd') ? scope['::fail2ban::jail_ports']['sshd'] : 'ssh' %>
 filter  = sshd
 logpath = %(sshd_log)s
 
@@ -227,13 +227,14 @@ logpath = %(sshd_log)s
 # The mail-whois action send a notification e-mail with a whois request
 # in the boidy.
 enabled = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd-ddos') ? scope['::fail2ban::jail_ports']['sshd-ddos'] : 'ssh' %>
 filter  = sshd
 logpath = %(sshd_log)s
 
 
 [dropbear]
 enabled = <%= scope['::fail2ban::jails'].include? "dropbear" %>
+port    = <%= scope['::fail2ban::jail_ports'].key?('dropbear') ? scope['::fail2ban::jail_ports']['dropbear'] : 'ssh' %>
 port     = ssh
 filter   = sshd
 logpath  = %(dropbear_log)s
@@ -241,7 +242,7 @@ logpath  = %(dropbear_log)s
 
 [selinux-ssh]
 enabled = <%= scope['::fail2ban::jails'].include? "selinux-ssh" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('selinux-ssh') ? scope['::fail2ban::jail_ports']['selinux-ssh'] : 'ssh' %>
 filter   = sshd
 logpath  = %(auditd_log)s
 maxretry = 5
@@ -253,7 +254,7 @@ maxretry = 5
 
 [apache-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-auth') ? scope['::fail2ban::jail_ports']['apache-auth'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 
 
@@ -261,7 +262,7 @@ logpath  = %(apache_error_log)s
 # Ban hosts which agent identifies spammer robots crawling the web
 # for email addresses. The mail outputs are buffered.
 # enabled = <%= scope['::fail2ban::jails'].include? "apache-badbots" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-badbots') ? scope['::fail2ban::jail_ports']['apache-badbots'] : 'http,https' %>
 logpath  = %(apache_access_log)s
 bantime  = 172800
 maxretry = 1
@@ -269,35 +270,35 @@ maxretry = 1
 
 [apache-noscript]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-noscript') ? scope['::fail2ban::jail_ports']['apache-noscript'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 6
 
 
 [apache-overflows]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-overflows') ? scope['::fail2ban::jail_ports']['apache-overflows'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-nohome]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-nohome" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-nohome') ? scope['::fail2ban::jail_ports']['apache-nohome'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-botsearch]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-botsearch" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-botsearch') ? scope['::fail2ban::jail_ports']['apache-botsearch'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-fakegooglebot]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-fakegooglebot" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-fakegooglebot') ? scope['::fail2ban::jail_ports']['apache-fakegooglebot'] : 'http,https' %>
 logpath  = %(apache_access_log)s
 maxretry = 1
 ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
@@ -305,24 +306,24 @@ ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
 
 [apache-modsecurity]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-modsecurity" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-modsecurity') ? scope['::fail2ban::jail_ports']['apache-modsecurity'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 [apache-shellshock]
 enabled = <%= scope['::fail2ban::jails'].include? "apache-shellshock" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('apache-shellshock') ? scope['::fail2ban::jail_ports']['apache-shellshock'] : 'http,https' %>
 logpath = %(apache_error_log)s
 maxretry = 1
 
 [nginx-http-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-http-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('nginx-http-auth') ? scope['::fail2ban::jail_ports']['nginx-http-auth'] : 'http,https' %>
 logpath = %(nginx_error_log)s
 
 [nginx-botsearch]
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-botsearch" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('nginx-botsearch') ? scope['::fail2ban::jail_ports']['nginx-botsearch'] : 'http,https' %>
 logpath  = %(nginx_error_log)s
 maxretry = 2
 
@@ -332,14 +333,14 @@ maxretry = 2
 
 [php-url-fopen]
 enabled = <%= scope['::fail2ban::jails'].include? "php-url-fopen" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('php-url-fopen') ? scope['::fail2ban::jail_ports']['php-url-fopen'] : 'http,https' %>
 logpath = %(nginx_access_log)s
           %(apache_access_log)s
 
 
 [suhosin]
 enabled = <%= scope['::fail2ban::jails'].include? "suhosin" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('suhosin') ? scope['::fail2ban::jail_ports']['suhosin'] : 'http,https' %>
 logpath = %(suhosin_log)s
 
 
@@ -347,7 +348,7 @@ logpath = %(suhosin_log)s
 # Same as above for Apache's mod_auth
 # It catches wrong authentifications
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('lighttpd-auth') ? scope['::fail2ban::jail_ports']['lighttpd-auth'] : 'http,https' %>
 logpath = %(lighttpd_error_log)s
 
 
@@ -357,25 +358,25 @@ logpath = %(lighttpd_error_log)s
 
 [roundcube-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "roundcube-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('roundcube-auth') ? scope['::fail2ban::jail_ports']['roundcube-auth'] : 'http,https' %>
 logpath  = /var/log/roundcube/userlogins
 
 
 [openwebmail]
 enabled = <%= scope['::fail2ban::jails'].include? "openwebmail" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('openwebmail') ? scope['::fail2ban::jail_ports']['openwebmail'] : 'http,https' %>
 logpath  = /var/log/openwebmail.log
 
 
 [horde]
 enabled = <%= scope['::fail2ban::jails'].include? "horde" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('horde') ? scope['::fail2ban::jail_ports']['horde'] : 'http,https' %>
 logpath  = /var/log/horde/horde.log
 
 
 [groupoffice]
 enabled = <%= scope['::fail2ban::jails'].include? "groupoffice" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('groupoffice') ? scope['::fail2ban::jail_ports']['groupoffice'] : 'http,https' %>
 logpath  = /home/groupoffice/log/info.log
 
 
@@ -384,14 +385,14 @@ logpath  = /home/groupoffice/log/info.log
 # without proxy this would be:
 # port    = 20000
 enabled = <%= scope['::fail2ban::jails'].include? "sogo-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('sogo-auth') ? scope['::fail2ban::jail_ports']['sogo-auth'] : 'http,https' %>
 logpath  = /var/log/sogo/sogo.log
 
 
 [tine20]
 enabled = <%= scope['::fail2ban::jails'].include? "tine20" %>
 logpath  = /var/log/tine20/tine20.log
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('tine20') ? scope['::fail2ban::jail_ports']['tine20'] : 'http,https' %>
 maxretry = 5
 
 
@@ -402,25 +403,25 @@ maxretry = 5
 
 [drupal-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "drupal-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('drupal-auth') ? scope['::fail2ban::jail_ports']['drupal-auth'] : 'http,https' %>
 logpath  = %(syslog_daemon)s
 
 [guacamole]
 enabled = <%= scope['::fail2ban::jails'].include? "guacamole" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('guacamole') ? scope['::fail2ban::jail_ports']['guacamole'] : 'http,https' %>
 logpath  = /var/log/tomcat*/catalina.out
 
 [monit]
 #Ban clients brute-forcing the monit gui login
 enabled = <%= scope['::fail2ban::jails'].include? "monit" %>
 filter   = monit
-port = 2812
+port = <%= scope['::fail2ban::jail_ports'].key?('monit') ? scope['::fail2ban::jail_ports']['monit'] : '2812' %>
 logpath  = /var/log/monit
 
 
 [webmin-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "webmin-auth" %>
-port    = 10000
+port    = <%= scope['::fail2ban::jail_ports'].key?('webmin-auth') ? scope['::fail2ban::jail_ports']['webmin-auth'] : '10000' %>
 logpath = %(syslog_authpriv)s
 
 
@@ -431,13 +432,13 @@ logpath = %(syslog_authpriv)s
 
 [squid]
 enabled = <%= scope['::fail2ban::jails'].include? "squid" %>
-port     =  80,443,3128,8080
+port     = <%= scope['::fail2ban::jail_ports'].key?('squid') ? scope['::fail2ban::jail_ports']['squid'] : '80,443,3128,8080' %>
 logpath = /var/log/squid/access.log
 
 
 [3proxy]
 enabled = <%= scope['::fail2ban::jails'].include? "3proxy" %>
-port    = 3128
+port    = <%= scope['::fail2ban::jail_ports'].key?('3proxy') ? scope['::fail2ban::jail_ports']['3proxy'] : '3128' %>
 logpath = /var/log/3proxy.log
 
 #
@@ -447,27 +448,27 @@ logpath = /var/log/3proxy.log
 
 [proftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "proftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('proftpd') ? scope['::fail2ban::jail_ports']['proftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(proftpd_log)s
 
 
 [pure-ftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('pure-ftpd') ? scope['::fail2ban::jail_ports']['pure-ftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(pureftpd_log)s
 maxretry = 6
 
 
 [gssftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "gssftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('gssftpd') ? scope['::fail2ban::jail_ports']['gssftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(syslog_daemon)s
 maxretry = 6
 
 
 [wuftpd]
 enabled = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('wuftpd') ? scope['::fail2ban::jail_ports']['wuftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(wuftpd_log)s
 maxretry = 6
 
@@ -478,7 +479,7 @@ maxretry = 6
 # if you want to rely on PAM failed login attempts
 # vsftpd's failregex should match both of those formats
 enabled = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('vsftpd') ? scope['::fail2ban::jail_ports']['vsftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(vsftpd_log)s
 
 
@@ -489,45 +490,45 @@ logpath  = %(vsftpd_log)s
 # ASSP SMTP Proxy Jail
 [assp]
 enabled = <%= scope['::fail2ban::jails'].include? "assp" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('assp') ? scope['::fail2ban::jail_ports']['assp'] : 'smtp,465,submission' %>
 logpath  = /root/path/to/assp/logs/maillog.txt
 
 
 [courier-smtp]
 enabled = <%= scope['::fail2ban::jails'].include? "courier-smtp" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-smtp') ? scope['::fail2ban::jail_ports']['courier-smtp'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 
 
 [postfix]
 enabled = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix') ? scope['::fail2ban::jail_ports']['postfix'] : 'smtp,465,submission' %>
 logpath  = %(postfix_log)s
 
 
 [postfix-rbl]
 enabled = <%= scope['::fail2ban::jails'].include? "postfix-rbl" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-rbl') ? scope['::fail2ban::jail_ports']['postfix-rbl'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 maxretry = 1
 
 
 [sendmail-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "sendmail-auth" %>
-port    = submission,465,smtp
+port    = <%= scope['::fail2ban::jail_ports'].key?('sendmail-auth') ? scope['::fail2ban::jail_ports']['sendmail-auth'] : 'smtp,465,submission' %>
 logpath = %(syslog_mail)s
 
 
 [sendmail-reject]
 enabled = <%= scope['::fail2ban::jails'].include? "sendmail-reject" %>
-port     = smtp,465,submission
+port    = <%= scope['::fail2ban::jail_ports'].key?('sendmail-reject') ? scope['::fail2ban::jail_ports']['sendmail-reject'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 
 
 [qmail-rbl]
 enabled = <%= scope['::fail2ban::jails'].include? "qmail-rbl" %>
 filter  = qmail
-port    = smtp,465,submission
+port    = <%= scope['::fail2ban::jail_ports'].key?('qmail-rbl') ? scope['::fail2ban::jail_ports']['qmail-rbl'] : 'smtp,465,submission' %>
 logpath = /service/qmail/log/main/current
 
 
@@ -535,37 +536,37 @@ logpath = /service/qmail/log/main/current
 # but can be set by syslog_facility in the dovecot configuration.
 [dovecot]
 enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
-port    = pop3,pop3s,imap,imaps,submission,465,sieve
+port    = <%= scope['::fail2ban::jail_ports'].key?('dovecot') ? scope['::fail2ban::jail_ports']['dovecot'] : 'pop3,pop3s,imap,imaps,submission,465,sieve' %>
 logpath = %(dovecot_log)s
 
 
 [sieve]
 enabled = <%= scope['::fail2ban::jails'].include? "sieve" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('sieve') ? scope['::fail2ban::jail_ports']['sieve'] : 'smtp,465,submission' %>
 logpath = %(dovecot_log)s
 
 
 [solid-pop3d]
 enabled = <%= scope['::fail2ban::jails'].include? "solid-pop3d" %>
-port    = pop3,pop3s
+port    = <%= scope['::fail2ban::jail_ports'].key?('solid-pop3d') ? scope['::fail2ban::jail_ports']['solid-pop3d'] : 'pop3,pop3s' %>
 logpath = %(solidpop3d_log)s
 
 
 [exim]
 enabled = <%= scope['::fail2ban::jails'].include? "exim" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('exim') ? scope['::fail2ban::jail_ports']['exim'] : 'smtp,465,submission' %>
 logpath = %(exim_main_log)s
 
 
 [exim-spam]
 enabled = <%= scope['::fail2ban::jails'].include? "exim-spam" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('exim-spam') ? scope['::fail2ban::jail_ports']['exim-spam'] : 'smtp,465,submission' %>
 logpath = %(exim_main_log)s
 
 
 [kerio]
 enabled = <%= scope['::fail2ban::jails'].include? "kerio" %>
-port    = imap,smtp,imaps,465
+port    = <%= scope['::fail2ban::jail_ports'].key?('kerio') ? scope['::fail2ban::jail_ports']['kerio'] : 'imap,smtp,imaps,465' %>
 logpath = /opt/kerio/mailserver/store/logs/security.log
 
 
@@ -576,13 +577,13 @@ logpath = /opt/kerio/mailserver/store/logs/security.log
 
 [courier-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "courier-auth" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-auth') ? scope['::fail2ban::jail_ports']['courier-auth'] : 'smtp,465,submission,imap3,imaps,pop3,pop3s' %>
 logpath  = %(syslog_mail)s
 
 
 [postfix-sasl]
 enabled = <%= scope['::fail2ban::jails'].include? "postfix-sasl" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-sasl') ? scope['::fail2ban::jail_ports']['postfix-sasl'] : 'smtp,465,submission,imap3,imaps,pop3,pop3s' %>
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
 # "warn" level but overall at the smaller filesize.
@@ -591,25 +592,25 @@ logpath  = %(postfix_log)s
 
 [perdition]
 enabled = <%= scope['::fail2ban::jails'].include? "perdition" %>
-port   = imap3,imaps,pop3,pop3s
+port   = <%= scope['::fail2ban::jail_ports'].key?('perdition') ? scope['::fail2ban::jail_ports']['perdition'] : 'imap3,imaps,pop3,pop3s' %>
 logpath = %(syslog_mail)s
 
 
 [squirrelmail]
 enabled = <%= scope['::fail2ban::jails'].include? "squirrelmail" %>
-port = smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks
+port = <%= scope['::fail2ban::jail_ports'].key?('squirrelmail') ? scope['::fail2ban::jail_ports']['squirrelmail'] : 'smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks' %>
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 
 [cyrus-imap]
 enabled = <%= scope['::fail2ban::jails'].include? "cyrus-imap" %>
-port   = imap3,imaps
+port   = <%= scope['::fail2ban::jail_ports'].key?('cyrus-imap') ? scope['::fail2ban::jail_ports']['cyrus-imap'] : 'imap3,imaps' %>
 logpath = %(syslog_mail)s
 
 
 [uwimap-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "uwimap-auth" %>
-port   = imap3,imaps
+port   = <%= scope['::fail2ban::jail_ports'].key?('uwimap-auth') ? scope['::fail2ban::jail_ports']['uwimap-auth'] : 'imap3,imaps' %>
 logpath = %(syslog_mail)s
 
 
@@ -641,13 +642,13 @@ logpath = %(syslog_mail)s
 
 [named-refused]
 enabled = <%= scope['::fail2ban::jails'].include? "named-refused" %>
-port     = domain,953
+port     = <%= scope['::fail2ban::jail_ports'].key?('named-refused') ? scope['::fail2ban::jail_ports']['named-refused'] : 'domain,953' %>
 logpath  = /var/log/named/security.log
 
 
 [nsd]
 enabled = <%= scope['::fail2ban::jails'].include? "nsd" %>
-port     = 53
+port     = <%= scope['::fail2ban::jail_ports'].key?('nsd') ? scope['::fail2ban::jail_ports']['nsd'] : '53' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
 logpath = /var/log/nsd.log
@@ -659,7 +660,7 @@ logpath = /var/log/nsd.log
 
 [asterisk]
 enabled = <%= scope['::fail2ban::jails'].include? "asterisk" %>
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('asterisk') ? scope['::fail2ban::jail_ports']['asterisk'] : '5060,5061' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
@@ -669,7 +670,7 @@ maxretry = 10
 
 [freeswitch]
 enabled = <%= scope['::fail2ban::jails'].include? "freeswitch" %>
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('freeswitch') ? scope['::fail2ban::jail_ports']['freeswitch'] : '5060,5061' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
@@ -690,7 +691,7 @@ maxretry = 10
 # log-error=/var/log/mysqld.log
 [mysqld-auth]
 enabled = <%= scope['::fail2ban::jails'].include? "mysqld-auth" %>
-port     = 3306
+port     = <%= scope['::fail2ban::jail_ports'].key?('mysqld-auth') ? scope['::fail2ban::jail_ports']['mysqld-auth'] : '3306' %>
 logpath  = %(mysql_log)s
 maxretry = 5
 
@@ -744,7 +745,8 @@ logpath = /var/log/ejabberd/ejabberd.log
 enabled = <%= scope['::fail2ban::jails'].include? "counter-strike" %>
 logpath = /opt/cstrike/logs/L[0-9]*.log
 # Firewall: http://www.cstrike-planet.com/faq/6
-tcpport = 27030,27031,27032,27033,27034,27035,27036,27037,27038,27039
+# CAUTION: variable jail_ports would only ban TCP ports
+tcpport = <%= scope['::fail2ban::jail_ports'].key?('counter-strike') ? scope['::fail2ban::jail_ports']['counter-strike'] : '27030,27031,27032,27033,27034,27035 ,27036,27037,27038,27039' %>
 udpport = 1200,27000,27001,27002,27003,27004,27005,27006,27007,27008,27009,27010,27011,27012,27013,27014,27015
 action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
@@ -767,7 +769,7 @@ banaction = iptables-allports
 [directadmin]
 enabled = <%= scope['::fail2ban::jails'].include? "directadmin" %>
 logpath = /var/log/directadmin/login.log
-port = 2222
+port = <%= scope['::fail2ban::jail_ports'].key?('directadmin') ? scope['::fail2ban::jail_ports']['directadmin'] : '2222' %>
 
 [portsentry]
 enabled = <%= scope['::fail2ban::jails'].include? "portsentry" %>

--- a/templates/Tikanga/etc/fail2ban/jail.conf.erb
+++ b/templates/Tikanga/etc/fail2ban/jail.conf.erb
@@ -138,7 +138,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 [ssh]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('ssh') ? scope['::fail2ban::jail_ports']['ssh'] : 'ssh' %>
 filter   = sshd
 logpath  = /var/log/secure
 maxretry = 6
@@ -146,7 +146,7 @@ maxretry = 6
 [dropbear]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "dropbear" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('dropbear') ? scope['::fail2ban::jail_ports']['dropbear'] : 'ssh' %>
 filter   = dropbear
 logpath  = /var/log/secure
 maxretry = 6
@@ -178,7 +178,7 @@ maxretry  = 2
 [ssh-ddos]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
-port     = ssh
+port     = <%= scope['::fail2ban::jail_ports'].key?('sshd-ddos') ? scope['::fail2ban::jail_ports']['sshd-ddos'] : 'ssh' %>
 filter   = sshd-ddos
 logpath  = /var/log/secure
 maxretry = 6
@@ -203,7 +203,7 @@ maxretry = 6
 [ssh-iptables-ipset4]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-iptables-ipset4" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('ssh-iptables-ipset4') ? scope['::fail2ban::jail_ports']['ssh-iptables-ipset4'] : 'ssh' %>
 filter   = sshd
 banaction = iptables-ipset-proto4
 logpath  = /var/log/sshd.log
@@ -212,7 +212,7 @@ maxretry = 6
 [ssh-iptables-ipset6]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-iptables-ipset6" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('ssh-iptables-ipset6') ? scope['::fail2ban::jail_ports']['ssh-iptables-ipset6'] : 'ssh' %>
 filter   = sshd
 banaction = iptables-ipset-proto6
 logpath  = /var/log/sshd.log
@@ -226,7 +226,7 @@ maxretry = 6
 [apache]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache') ? scope['::fail2ban::jail_ports']['apache'] : 'http,https' %>
 filter   = apache-auth
 logpath  = /var/log/apache*/*error.log
 maxretry = 6
@@ -236,7 +236,7 @@ maxretry = 6
 [apache-multiport]
 
 enabled   = <%= scope['::fail2ban::jails'].include? "apache-multiport" %>
-port      = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-multiport') ? scope['::fail2ban::jail_ports']['apache-multiport'] : 'http,https' %>
 filter    = apache-auth
 logpath   = /var/log/apache*/*error.log
 maxretry  = 6
@@ -244,7 +244,7 @@ maxretry  = 6
 [apache-noscript]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-noscript') ? scope['::fail2ban::jail_ports']['apache-noscript'] : 'http,https' %>
 filter   = apache-noscript
 logpath  = /var/log/apache*/*error.log
 maxretry = 6
@@ -252,7 +252,7 @@ maxretry = 6
 [apache-overflows]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-overflows') ? scope['::fail2ban::jail_ports']['apache-overflows'] : 'http,https' %>
 filter   = apache-overflows
 logpath  = /var/log/apache*/*error.log
 maxretry = 2
@@ -261,7 +261,7 @@ maxretry = 2
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-modsecurity" %>
 filter   = apache-modsecurity
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-modsecurity') ? scope['::fail2ban::jail_ports']['apache-modsecurity'] : 'http,https' %>
 logpath  = /var/log/apache*/*error.log
 maxretry = 2
 
@@ -269,7 +269,7 @@ maxretry = 2
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-nohome" %>
 filter   = apache-nohome
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-nohome') ? scope['::fail2ban::jail_ports']['apache-nohome'] : 'http,https' %>
 logpath  = /var/log/apache*/*error.log
 maxretry = 2
 
@@ -280,7 +280,7 @@ maxretry = 2
 [php-url-fopen]
 
 enabled = <%= scope['::fail2ban::jails'].include? "php-url-fopen" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('php-url-fopen') ? scope['::fail2ban::jail_ports']['php-url-fopen'] : 'http,https' %>
 filter  = php-url-fopen
 logpath = /var/www/*/logs/access_log
 
@@ -293,7 +293,7 @@ logpath = /var/www/*/logs/access_log
 [lighttpd-fastcgi]
 
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-fastcgi" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('lighttpd-fastcgi') ? scope['::fail2ban::jail_ports']['lighttpd-fastcgi'] : 'http,https' %>
 filter  = lighttpd-fastcgi
 logpath = /var/log/lighttpd/error.log
 
@@ -303,7 +303,7 @@ logpath = /var/log/lighttpd/error.log
 [lighttpd-auth]
 
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('lighttpd-auth') ? scope['::fail2ban::jail_ports']['lighttpd-auth'] : 'http,https' %>
 filter  = suhosin
 logpath = /var/log/lighttpd/error.log
 
@@ -311,7 +311,7 @@ logpath = /var/log/lighttpd/error.log
 
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-http-auth" %>
 filter  = nginx-http-auth
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('nginx-http-auth') ? scope['::fail2ban::jail_ports']['nginx-http-auth'] : 'http,https' %>
 logpath = /var/log/nginx/error.log
 
 # Monitor roundcube server
@@ -320,7 +320,7 @@ logpath = /var/log/nginx/error.log
 
 enabled  = <%= scope['::fail2ban::jails'].include? "roundcube-auth" %>
 filter   = roundcube-auth
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('roundcube-auth') ? scope['::fail2ban::jail_ports']['roundcube-auth'] : 'http,https' %>
 logpath  = /var/log/roundcube/userlogins
 
 
@@ -328,7 +328,7 @@ logpath  = /var/log/roundcube/userlogins
 
 enabled  = <%= scope['::fail2ban::jails'].include? "sogo-auth" %>
 filter   = sogo-auth
-port     = http, https
+port     = <%= scope['::fail2ban::jail_ports'].key?('sogo-auth') ? scope['::fail2ban::jail_ports']['sogo-auth'] : 'http,https' %>
 # without proxy this would be:
 # port    = 20000
 logpath  = /var/log/sogo/sogo.log
@@ -341,7 +341,7 @@ logpath  = /var/log/sogo/sogo.log
 [vsftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('vsftpd') ? scope['::fail2ban::jail_ports']['vsftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = vsftpd
 logpath  = /var/log/vsftpd.log
 # or overwrite it in jails.local to be
@@ -354,7 +354,7 @@ maxretry = 6
 [proftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "proftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('proftpd') ? scope['::fail2ban::jail_ports']['proftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = proftpd
 logpath  = /var/log/proftpd/proftpd.log
 maxretry = 6
@@ -363,7 +363,7 @@ maxretry = 6
 [pure-ftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('pure-ftpd') ? scope['::fail2ban::jail_ports']['pure-ftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = pure-ftpd
 logpath  = /var/log/syslog
 maxretry = 6
@@ -372,7 +372,7 @@ maxretry = 6
 [wuftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('wuftpd') ? scope['::fail2ban::jail_ports']['wuftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = wuftpd
 logpath  = /var/log/syslog
 maxretry = 6
@@ -385,7 +385,7 @@ maxretry = 6
 [postfix]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port     = smtp,ssmtp,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix') ? scope['::fail2ban::jail_ports']['postfix'] : 'smtp,ssmtp,submission' %>
 filter   = postfix
 logpath  = /var/log/mail.log
 
@@ -393,7 +393,7 @@ logpath  = /var/log/mail.log
 [couriersmtp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "couriersmtp" %>
-port     = smtp,ssmtp,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-smtp') ? scope['::fail2ban::jail_ports']['courier-smtp'] : 'smtp,ssmtp,submission' %>
 filter   = couriersmtp
 logpath  = /var/log/mail.log
 
@@ -406,7 +406,7 @@ logpath  = /var/log/mail.log
 [courierauth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "courierauth" %>
-port     = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('courierauth') ? scope['::fail2ban::jail_ports']['courierauth'] : 'smtp,ssmtp,submission,imap3,imaps,pop3,pop3s' %>
 filter   = courierlogin
 logpath  = /var/log/mail.log
 
@@ -414,7 +414,7 @@ logpath  = /var/log/mail.log
 [sasl]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "sasl" %>
-port     = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-sasl') ? scope['::fail2ban::jail_ports']['postfix-sasl'] : 'smtp,ssmtp,submission,imap3,imaps,pop3,pop3s' %>
 filter   = postfix-sasl
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
@@ -425,6 +425,7 @@ logpath  = /var/log/mail.log
 
 enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
 port    = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
+port    = <%= scope['::fail2ban::jail_ports'].key?('dovecot') ? scope['::fail2ban::jail_ports']['dovecot'] : 'smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s' %>
 filter  = dovecot
 logpath = /var/log/mail.log
 
@@ -435,7 +436,7 @@ logpath = /var/log/mail.log
 
 enabled  = <%= scope['::fail2ban::jails'].include? "mysqld-auth" %>
 filter   = mysqld-auth
-port     = 3306
+port     = <%= scope['::fail2ban::jail_ports'].key?('mysqld-auth') ? scope['::fail2ban::jail_ports']['mysqld-auth'] : '3306' %>
 logpath  = /var/log/mysqld.log
 
 
@@ -476,7 +477,7 @@ logpath  = /var/log/mysqld.log
 [named-refused-tcp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "named-refused-tcp" %>
-port     = domain,953
+port     = <%= scope['::fail2ban::jail_ports'].key?('named-refused-tcp') ? scope['::fail2ban::jail_ports']['named-refused-tcp'] : 'domain,953' %>
 protocol = tcp
 filter   = named-refused
 logpath  = /var/log/named/security.log
@@ -487,14 +488,14 @@ enabled  = <%= scope['::fail2ban::jails'].include? "freeswitch" %>
 filter   = freeswitch
 logpath  = /var/log/freeswitch.log
 maxretry = 10
-action   = iptables-multiport[name=freeswitch-tcp, port="5060,5061,5080,5081", protocol=tcp]
-           iptables-multiport[name=freeswitch-udp, port="5060,5061,5080,5081", protocol=udp]
+action   = iptables-multiport[name=freeswitch-tcp, port="<%= scope['::fail2ban::jail_ports'].key?('freeswitch') ? scope['::fail2ban::jail_ports']['freeswitch'] : '5060,5061,5080,5081' %>" , protocol=tcp]
+           iptables-multiport[name=freeswitch-udp, port="<%= scope['::fail2ban::jail_ports'].key?('freeswitch') ? scope['::fail2ban::jail_ports']['freeswitch'] : '5060,5061,5080,5081' %>", protocol=udp]
 
 [ejabberd-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ejabberd-auth" %>
 filter   = ejabberd-auth
-port     = xmpp-client
+port    = <%= scope['::fail2ban::jail_ports'].key?('ejabberd-auth') ? scope['::fail2ban::jail_ports']['ejabberd-auth'] : 'xmpp-client' %>
 protocol = tcp
 logpath  = /var/log/ejabberd/ejabberd.log
 
@@ -505,7 +506,7 @@ logpath  = /var/log/ejabberd/ejabberd.log
 
 enabled  = <%= scope['::fail2ban::jails'].include? "asterisk-tcp" %>
 filter   = asterisk
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('asterisk-tcp') ? scope['::fail2ban::jail_ports']['asterisk-tcp'] : '5060,5061' %>
 protocol = tcp
 logpath  = /var/log/asterisk/messages
 
@@ -513,7 +514,7 @@ logpath  = /var/log/asterisk/messages
 
 enabled  = <%= scope['::fail2ban::jails'].include? "asterisk-udp" %>
 filter	 = asterisk
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('asterisk-udp') ? scope['::fail2ban::jail_ports']['asterisk-udp'] : '5060,5061' %>
 protocol = udp
 logpath  = /var/log/asterisk/messages
 
@@ -543,7 +544,7 @@ maxretry = 5
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-blocklist" %>
 filter   = sshd
-action   = iptables[name=SSH, port=ssh, protocol=tcp]
+action   = iptables[name=SSH, port=<%= scope['::fail2ban::jail_ports'].key?('ssh-blocklist') ? scope['::fail2ban::jail_ports']['ssh-blocklist'] : 'ssh' %>, protocol=tcp]
            sendmail-whois[name=SSH, dest="%(destemail)s", sender="%(sender)s", sendername="%(sendername)s"]
            blocklist_de[email="%(sender)s", apikey="xxxxxx", service="%(filter)s"]
 logpath  = /var/log/sshd.log
@@ -555,7 +556,7 @@ maxretry = 20
 [nagios]
 enabled  = <%= scope['::fail2ban::jails'].include? "nagios" %>
 filter   = nagios
-action   = iptables[name=Nagios, port=5666, protocol=tcp]
+action   = iptables[name=Nagios, port=<%= scope['::fail2ban::jail_ports'].key?('nagios') ? scope['::fail2ban::jail_ports']['nagios'] : '5666' %>, protocol=tcp]
            sendmail-whois[name=Nagios, dest="%(destemail)s", sender="%(sender)s", sendername="%(sendername)s"]
 logpath  = /var/log/messages     ; nrpe.cfg may define a different log_facility
 maxretry = 1

--- a/templates/jessie/etc/fail2ban/jail.conf.erb
+++ b/templates/jessie/etc/fail2ban/jail.conf.erb
@@ -138,7 +138,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 [ssh]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh" %>
-port     = ssh
+port     = <%= scope['::fail2ban::jail_ports'].key?('ssh') ? scope['::fail2ban::jail_ports']['ssh'] : 'ssh' %>
 filter   = sshd
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -146,7 +146,7 @@ maxretry = 6
 [dropbear]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "dropbear" %>
-port     = ssh
+port     = <%= scope['::fail2ban::jail_ports'].key?('dropbear') ? scope['::fail2ban::jail_ports']['dropbear'] : 'ssh' %>
 filter   = dropbear
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -178,7 +178,7 @@ maxretry  = 2
 [ssh-ddos]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
-port     = ssh
+port     = <%= scope['::fail2ban::jail_ports'].key?('ssh-ddos') ? scope['::fail2ban::jail_ports']['ssh-ddos'] : 'ssh' %>
 filter   = sshd-ddos
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -203,7 +203,7 @@ maxretry = 6
 [ssh-iptables-ipset4]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-iptables-ipset4" %>
-port     = ssh
+port     = <%= scope['::fail2ban::jail_ports'].key?('ssh-iptables-ipset4') ? scope['::fail2ban::jail_ports']['ssh-iptables-ipset4'] : 'ssh' %>
 filter   = sshd
 banaction = iptables-ipset-proto4
 logpath  = /var/log/sshd.log
@@ -212,7 +212,7 @@ maxretry = 6
 [ssh-iptables-ipset6]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-iptables-ipset6" %>
-port     = ssh
+port     = <%= scope['::fail2ban::jail_ports'].key?('ssh-iptables-ipset6') ? scope['::fail2ban::jail_ports']['ssh-iptables-ipset6'] : 'ssh' %>
 filter   = sshd
 banaction = iptables-ipset-proto6
 logpath  = /var/log/sshd.log
@@ -226,7 +226,7 @@ maxretry = 6
 [apache]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache') ? scope['::fail2ban::jail_ports']['apache'] : 'http,https' %>
 filter   = apache-auth
 logpath  = /var/log/apache*/*error.log
 maxretry = 6
@@ -236,7 +236,7 @@ maxretry = 6
 [apache-multiport]
 
 enabled   = <%= scope['::fail2ban::jails'].include? "apache-multiport" %>
-port      = http,https
+port      = <%= scope['::fail2ban::jail_ports'].key?('apache-multiport') ? scope['::fail2ban::jail_ports']['apache-multiport'] : 'http,https' %>
 filter    = apache-auth
 logpath   = /var/log/apache*/*error.log
 maxretry  = 6
@@ -244,7 +244,7 @@ maxretry  = 6
 [apache-noscript]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
-port     = http,https
+port      = <%= scope['::fail2ban::jail_ports'].key?('apache-noscript') ? scope['::fail2ban::jail_ports']['apache-noscript'] : 'http,https' %>
 filter   = apache-noscript
 logpath  = /var/log/apache*/*error.log
 maxretry = 6
@@ -252,7 +252,8 @@ maxretry = 6
 [apache-overflows]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-overflows') ? scope['::fail2ban::jail_ports']['apache-overflows'] : 'http,https' %>
+
 filter   = apache-overflows
 logpath  = /var/log/apache*/*error.log
 maxretry = 2
@@ -261,7 +262,7 @@ maxretry = 2
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-modsecurity" %>
 filter   = apache-modsecurity
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-modsecurity') ? scope['::fail2ban::jail_ports']['apache-modsecurity'] : 'http,https' %>
 logpath  = /var/log/apache*/*error.log
 maxretry = 2
 
@@ -269,7 +270,7 @@ maxretry = 2
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-nohome" %>
 filter   = apache-nohome
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-nohome') ? scope['::fail2ban::jail_ports']['apache-nohome'] : 'http,https' %>
 logpath  = /var/log/apache*/*error.log
 maxretry = 2
 
@@ -280,7 +281,7 @@ maxretry = 2
 [php-url-fopen]
 
 enabled = <%= scope['::fail2ban::jails'].include? "php-url-fopen" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('php-url-fopen') ? scope['::fail2ban::jail_ports']['php-url-fopen'] : 'http,https' %>
 filter  = php-url-fopen
 logpath = /var/www/*/logs/access_log
 
@@ -293,7 +294,7 @@ logpath = /var/www/*/logs/access_log
 [lighttpd-fastcgi]
 
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-fastcgi" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('lighttpd-fastcgi') ? scope['::fail2ban::jail_ports']['lighttpd-fastcgi'] : 'http,https' %>
 filter  = lighttpd-fastcgi
 logpath = /var/log/lighttpd/error.log
 
@@ -303,7 +304,7 @@ logpath = /var/log/lighttpd/error.log
 [lighttpd-auth]
 
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('lighttpd-auth') ? scope['::fail2ban::jail_ports']['lighttpd-auth'] : 'http,https' %>
 filter  = suhosin
 logpath = /var/log/lighttpd/error.log
 
@@ -311,7 +312,7 @@ logpath = /var/log/lighttpd/error.log
 
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-http-auth" %>
 filter  = nginx-http-auth
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('nginx-http-auth') ? scope['::fail2ban::jail_ports']['nginx-http-auth'] : 'http,https' %>
 logpath = /var/log/nginx/*error*.log
 
 # Monitor roundcube server
@@ -319,7 +320,7 @@ logpath = /var/log/nginx/*error*.log
 
 enabled  = <%= scope['::fail2ban::jails'].include? "roundcube-auth" %>
 filter   = roundcube-auth
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('roundcube-auth') ? scope['::fail2ban::jail_ports']['roundcube-auth'] : 'http,https' %>
 logpath  = /var/log/roundcube/userlogins
 
 
@@ -327,7 +328,8 @@ logpath  = /var/log/roundcube/userlogins
 
 enabled  = <%= scope['::fail2ban::jails'].include? "sogo-auth" %>
 filter   = sogo-auth
-port     = http, https
+port     = <%= scope['::fail2ban::jail_ports'].key?('sogo-auth') ? scope['::fail2ban::jail_ports']['sogo-auth'] : 'http,https' %>
+
 # without proxy this would be:
 # port    = 20000
 logpath  = /var/log/sogo/sogo.log
@@ -340,7 +342,7 @@ logpath  = /var/log/sogo/sogo.log
 [vsftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('vsftpd') ? scope['::fail2ban::jail_ports']['vsftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = vsftpd
 logpath  = /var/log/vsftpd.log
 # or overwrite it in jails.local to be
@@ -353,7 +355,7 @@ maxretry = 6
 [proftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "proftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('proftpd') ? scope['::fail2ban::jail_ports']['proftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = proftpd
 logpath  = /var/log/proftpd/proftpd.log
 maxretry = 6
@@ -362,7 +364,7 @@ maxretry = 6
 [pure-ftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('pure-ftpd') ? scope['::fail2ban::jail_ports']['pure-ftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = pure-ftpd
 logpath  = /var/log/syslog
 maxretry = 6
@@ -371,7 +373,7 @@ maxretry = 6
 [wuftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('wuftpd') ? scope['::fail2ban::jail_ports']['wuftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = wuftpd
 logpath  = /var/log/syslog
 maxretry = 6
@@ -384,7 +386,7 @@ maxretry = 6
 [postfix]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port     = smtp,ssmtp,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix') ? scope['::fail2ban::jail_ports']['postfix'] : 'smtp,ssmtp,submission' %>
 filter   = postfix
 logpath  = /var/log/mail.log
 
@@ -392,7 +394,7 @@ logpath  = /var/log/mail.log
 [couriersmtp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "couriersmtp" %>
-port     = smtp,ssmtp,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('couriersmtp') ? scope['::fail2ban::jail_ports']['couriersmtp'] : 'smtp,ssmtp,submission' %>
 filter   = couriersmtp
 logpath  = /var/log/mail.log
 
@@ -405,7 +407,7 @@ logpath  = /var/log/mail.log
 [courierauth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "courierauth" %>
-port     = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('courierauth') ? scope['::fail2ban::jail_ports']['courierauth'] : 'smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s' %>
 filter   = courierlogin
 logpath  = /var/log/mail.log
 
@@ -413,7 +415,7 @@ logpath  = /var/log/mail.log
 [sasl]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "sasl" %>
-port     = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('sasl') ? scope['::fail2ban::jail_ports']['sasl'] : 'smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s' %>
 filter   = postfix-sasl
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
@@ -423,7 +425,7 @@ logpath  = /var/log/mail.log
 [dovecot]
 
 enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
-port    = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
+port    = <%= scope['::fail2ban::jail_ports'].key?('dovecot') ? scope['::fail2ban::jail_ports']['dovecot'] : 'smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s' %>
 filter  = dovecot
 logpath = /var/log/mail.log
 
@@ -434,7 +436,7 @@ logpath = /var/log/mail.log
 
 enabled  = <%= scope['::fail2ban::jails'].include? "mysqld-auth" %>
 filter   = mysqld-auth
-port     = 3306
+port     = <%= scope['::fail2ban::jail_ports'].key?('mysqld-auth') ? scope['::fail2ban::jail_ports']['mysqld-auth'] : '3306' %>
 logpath  = /var/log/mysqld.log
 
 
@@ -475,7 +477,7 @@ logpath  = /var/log/mysqld.log
 [named-refused-tcp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "named-refused-tcp" %>
-port     = domain,953
+port     = <%= scope['::fail2ban::jail_ports'].key?('named-refused-tcp') ? scope['::fail2ban::jail_ports']['named-refused-tcp'] : 'domain,953' %>
 protocol = tcp
 filter   = named-refused
 logpath  = /var/log/named/security.log
@@ -486,14 +488,14 @@ enabled  = <%= scope['::fail2ban::jails'].include? "freeswitch" %>
 filter   = freeswitch
 logpath  = /var/log/freeswitch.log
 maxretry = 10
-action   = iptables-multiport[name=freeswitch-tcp, port="5060,5061,5080,5081", protocol=tcp]
-           iptables-multiport[name=freeswitch-udp, port="5060,5061,5080,5081", protocol=udp]
+action   = iptables-multiport[name=freeswitch-tcp, port=<%= scope['::fail2ban::jail_ports'].key?('freeswitch') ? scope['::fail2ban::jail_ports']['freeswitch'] : '5060,5061,5080,5081' %>, protocol=tcp]
+           iptables-multiport[name=freeswitch-udp, port=<%= scope['::fail2ban::jail_ports'].key?('freeswitch') ? scope['::fail2ban::jail_ports']['freeswitch'] : '5060,5061,5080,5081' %>, protocol=udp]
 
 [ejabberd-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ejabberd-auth" %>
 filter   = ejabberd-auth
-port     = xmpp-client
+port     = <%= scope['::fail2ban::jail_ports'].key?('ejabberd-auth') ? scope['::fail2ban::jail_ports']['ejabberd-auth'] : 'xmpp-client' %>
 protocol = tcp
 logpath  = /var/log/ejabberd/ejabberd.log
 
@@ -504,7 +506,7 @@ logpath  = /var/log/ejabberd/ejabberd.log
 
 enabled  = <%= scope['::fail2ban::jails'].include? "asterisk-tcp" %>
 filter   = asterisk
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('asterisk-tcp') ? scope['::fail2ban::jail_ports']['asterisk-tcp'] : '5060,5061' %>
 protocol = tcp
 logpath  = /var/log/asterisk/messages
 
@@ -512,7 +514,7 @@ logpath  = /var/log/asterisk/messages
 
 enabled  = <%= scope['::fail2ban::jails'].include? "asterisk-udp" %>
 filter	 = asterisk
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('asterisk-udp') ? scope['::fail2ban::jail_ports']['asterisk-udp'] : '5060,5061' %>
 protocol = udp
 logpath  = /var/log/asterisk/messages
 
@@ -542,7 +544,7 @@ maxretry = 5
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-blocklist" %>
 filter   = sshd
-action   = iptables[name=SSH, port=ssh, protocol=tcp]
+action   = iptables[name=SSH, port=<%= scope['::fail2ban::jail_ports'].key?('ssh-blocklist') ? scope['::fail2ban::jail_ports']['ssh-blocklist'] : 'ssh' %>, protocol=tcp]
            sendmail-whois[name=SSH, dest="%(destemail)s", sender="%(sender)s", sendername="%(sendername)s"]
            blocklist_de[email="%(sender)s", apikey="xxxxxx", service="%(filter)s"]
 logpath  = /var/log/sshd.log
@@ -554,7 +556,7 @@ maxretry = 20
 [nagios]
 enabled  = <%= scope['::fail2ban::jails'].include? "nagios" %>
 filter   = nagios
-action   = iptables[name=Nagios, port=5666, protocol=tcp]
+action   = iptables[name=Nagios, port=<%= scope['::fail2ban::jail_ports'].key?('nagios') ? scope['::fail2ban::jail_ports']['nagios'] : '5666' %>, protocol=tcp]
            sendmail-whois[name=Nagios, dest="%(destemail)s", sender="%(sender)s", sendername="%(sendername)s"]
 logpath  = /var/log/messages     ; nrpe.cfg may define a different log_facility
 maxretry = 1
@@ -568,7 +570,7 @@ maxretry = 1
 # wordpress login failures using nginx
 [nginx-wp-login]
 enabled = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-wp-login" %>
-port = http,https
+port = <%= scope['::fail2ban::jail_ports'].key?('nginx-wp-login') ? scope['::fail2ban::jail_ports']['nginx-wp-login'] : 'http,https' %>
 filter = nginx-wp-login
 logpath = /var/log/nginx/access.log
 maxretry = 3
@@ -579,7 +581,7 @@ bantime = 1200
 [nginx-login]
 enabled = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-login" %>
 filter = nginx-login
-action = iptables-multiport[name=NoLoginFailures, port="http,https"]
+action = iptables-multiport[name=NoLoginFailures, port=<%= scope['::fail2ban::jail_ports'].key?('nginx-login') ? scope['::fail2ban::jail_ports']['nginx-login'] : 'http,https' %>]
 logpath = /var/log/nginx*/*access*.log
 bantime = 600 # 10 minutes
 maxretry = 6
@@ -588,7 +590,7 @@ maxretry = 6
 [nginx-badbots]
 enabled  = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-badbots" %>
 filter = apache-badbots
-action = iptables-multiport[name=BadBots, port="http,https"]
+action = iptables-multiport[name=BadBots, port=<%= scope['::fail2ban::jail_ports'].key?('nginx-badbots') ? scope['::fail2ban::jail_ports']['nginx-badbots'] : 'http,https' %>]
 logpath = /var/log/nginx*/*access*.log
 bantime = 86400 # 1 day
 maxretry = 1
@@ -596,7 +598,7 @@ maxretry = 1
 # IPs trying to execute scripts
 [nginx-noscript]
 enabled = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-noscript" %>
-action = iptables-multiport[name=NoScript, port="http,https"]
+action = iptables-multiport[name=NoScript, port=<%= scope['::fail2ban::jail_ports'].key?('nginx-noscript') ? scope['::fail2ban::jail_ports']['nginx-noscript'] : 'http,https' %>]
 filter = nginx-noscript
 logpath = /var/log/nginx*/*access*.log
 maxretry = 6
@@ -605,7 +607,7 @@ bantime  = 86400 # 1 day
 # IPs trying to use server as proxy.
 [nginx-proxy]
 enabled = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-proxy" %>
-action = iptables-multiport[name=NoProxy, port="http,https"]
+action = iptables-multiport[name=NoProxy, port=<%= scope['::fail2ban::jail_ports'].key?('nginx-proxy') ? scope['::fail2ban::jail_ports']['nginx-proxy'] : 'http,https' %>]
 filter = nginx-proxy
 logpath = /var/log/nginx*/*access*.log
 maxretry = 0

--- a/templates/precise/etc/fail2ban/jail.conf.erb
+++ b/templates/precise/etc/fail2ban/jail.conf.erb
@@ -102,7 +102,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 [ssh]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh" %>
-port     = ssh
+port     = port    = <%= scope['::fail2ban::jail_ports'].key?('ssh') ? scope['::fail2ban::jail_ports']['ssh'] : 'ssh' %>
 filter   = sshd
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -110,7 +110,7 @@ maxretry = 6
 [dropbear]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "dropbear" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('dropbear') ? scope['::fail2ban::jail_ports']['dropbear'] : 'ssh' %>
 filter   = sshd
 logpath  = /var/log/dropbear
 maxretry = 6
@@ -142,7 +142,7 @@ maxretry  = 2
 [ssh-ddos]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
-port     = ssh
+port     = <%= scope['::fail2ban::jail_ports'].key?('sshd-ddos') ? scope['::fail2ban::jail_ports']['sshd-ddos'] : 'ssh' %>
 filter   = sshd-ddos
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -154,7 +154,7 @@ maxretry = 6
 [apache]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache') ? scope['::fail2ban::jail_ports']['apache'] : 'http,https' %>
 filter   = apache-auth
 logpath  = /var/log/apache*/*error.log
 maxretry = 6
@@ -164,7 +164,7 @@ maxretry = 6
 [apache-multiport]
 
 enabled   = <%= scope['::fail2ban::jails'].include? "apache-multiport" %>
-port      = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-multiport') ? scope['::fail2ban::jail_ports']['apache-multiport'] : 'http,https' %>
 filter    = apache-auth
 logpath   = /var/log/apache*/*error.log
 maxretry  = 6
@@ -172,7 +172,7 @@ maxretry  = 6
 [apache-noscript]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-noscript') ? scope['::fail2ban::jail_ports']['apache-noscript'] : 'http,https' %>
 filter   = apache-noscript
 logpath  = /var/log/apache*/*error.log
 maxretry = 6
@@ -180,7 +180,7 @@ maxretry = 6
 [apache-overflows]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-overflows') ? scope['::fail2ban::jail_ports']['apache-overflows'] : 'http,https' %>
 filter   = apache-overflows
 logpath  = /var/log/apache*/*error.log
 maxretry = 2
@@ -192,7 +192,7 @@ maxretry = 2
 [vsftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('vsftpd') ? scope['::fail2ban::jail_ports']['vsftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = vsftpd
 logpath  = /var/log/vsftpd.log
 # or overwrite it in jails.local to be
@@ -205,7 +205,7 @@ maxretry = 6
 [proftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "proftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('proftpd') ? scope['::fail2ban::jail_ports']['proftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = proftpd
 logpath  = /var/log/proftpd/proftpd.log
 maxretry = 6
@@ -214,7 +214,7 @@ maxretry = 6
 [pure-ftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('pure-ftpd') ? scope['::fail2ban::jail_ports']['pure-ftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = pure-ftpd
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -223,7 +223,7 @@ maxretry = 6
 [wuftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('wuftpd') ? scope['::fail2ban::jail_ports']['wuftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = wuftpd
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -236,7 +236,7 @@ maxretry = 6
 [postfix]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port     = smtp,ssmtp
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix') ? scope['::fail2ban::jail_ports']['postfix'] : 'smtp,ssmtp,submission' %>
 filter   = postfix
 logpath  = /var/log/mail.log
 
@@ -244,7 +244,7 @@ logpath  = /var/log/mail.log
 [couriersmtp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "couriersmtp" %>
-port     = smtp,ssmtp
+port     = <%= scope['::fail2ban::jail_ports'].key?('couriersmtp') ? scope['::fail2ban::jail_ports']['couriersmtp'] : 'smtp,ssmtp,submission' %>
 filter   = couriersmtp
 logpath  = /var/log/mail.log
 
@@ -257,7 +257,7 @@ logpath  = /var/log/mail.log
 [courierauth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "courierauth" %>
-port     = smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('courierauth') ? scope['::fail2ban::jail_ports']['courierauth'] : 'smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s' %>
 filter   = courierlogin
 logpath  = /var/log/mail.log
 
@@ -265,7 +265,8 @@ logpath  = /var/log/mail.log
 [sasl]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "sasl" %>
-port     = smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('sasl') ? scope['::fail2ban::jail_ports']['sasl'] : 'smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s' %>
+
 filter   = sasl
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
@@ -275,7 +276,8 @@ logpath  = /var/log/mail.log
 [dovecot]
 
 enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
-port    = smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s
+port    = <%= scope['::fail2ban::jail_ports'].key?('dovecot') ? scope['::fail2ban::jail_ports']['dovecot'] : 'smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s' %>
+
 filter  = dovecot
 logpath = /var/log/mail.log
 
@@ -316,7 +318,7 @@ logpath = /var/log/mail.log
 [named-refused-tcp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "named-refused-tcp" %>
-port     = domain,953
+port     = <%= scope['::fail2ban::jail_ports'].key?('named-refused-tcp') ? scope['::fail2ban::jail_ports']['named-refused-tcp'] : 'domain,953' %>
 protocol = tcp
 filter   = named-refused
 logpath  = /var/log/named/security.log

--- a/templates/squeeze/etc/fail2ban/jail.conf.erb
+++ b/templates/squeeze/etc/fail2ban/jail.conf.erb
@@ -99,7 +99,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 [ssh]
 
 enabled = <%= scope['::fail2ban::jails'].include? "ssh" %>
-port	= ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('ssh') ? scope['::fail2ban::jail_ports']['ssh'] : 'ssh' %>
 filter	= sshd
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -131,7 +131,7 @@ maxretry  = 2
 [ssh-ddos]
 
 enabled = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd-ddos') ? scope['::fail2ban::jail_ports']['sshd-ddos'] : 'ssh' %>
 filter  = sshd-ddos
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -143,7 +143,7 @@ maxretry = 6
 [apache]
 
 enabled = <%= scope['::fail2ban::jails'].include? "apache" %>
-port	= http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache') ? scope['::fail2ban::jail_ports']['apache'] : 'http,https' %>
 filter	= apache-auth
 logpath = /var/log/apache*/*error.log
 maxretry = 6
@@ -153,7 +153,7 @@ maxretry = 6
 [apache-multiport]
 
 enabled   = <%= scope['::fail2ban::jails'].include? "apache-multiport" %>
-port	  = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-multiport') ? scope['::fail2ban::jail_ports']['apache-multiport'] : 'http,https' %>
 filter	  = apache-auth
 logpath   = /var/log/apache*/*error.log
 maxretry  = 6
@@ -161,7 +161,7 @@ maxretry  = 6
 [apache-noscript]
 
 enabled = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
-port    = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-noscript') ? scope['::fail2ban::jail_ports']['apache-noscript'] : 'http,https' %>
 filter  = apache-noscript
 logpath = /var/log/apache*/*error.log
 maxretry = 6
@@ -169,7 +169,7 @@ maxretry = 6
 [apache-overflows]
 
 enabled = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
-port    = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-overflows') ? scope['::fail2ban::jail_ports']['apache-overflows'] : 'http,https' %>
 filter  = apache-overflows
 logpath = /var/log/apache*/*error.log
 maxretry = 2
@@ -181,7 +181,7 @@ maxretry = 2
 [vsftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port	 = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('vsftpd') ? scope['::fail2ban::jail_ports']['vsftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = vsftpd
 logpath  = /var/log/vsftpd.log
 # or overwrite it in jails.local to be
@@ -194,7 +194,7 @@ maxretry = 6
 [proftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "proftpd" %>
-port	 = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('proftpd') ? scope['::fail2ban::jail_ports']['proftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = proftpd
 logpath  = /var/log/proftpd/proftpd.log
 maxretry = 6
@@ -203,7 +203,7 @@ maxretry = 6
 [wuftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
-port	 = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('wuftpd') ? scope['::fail2ban::jail_ports']['wuftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = wuftpd
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -216,7 +216,7 @@ maxretry = 6
 [postfix]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port	 = smtp,ssmtp
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix') ? scope['::fail2ban::jail_ports']['postfix'] : 'smtp,ssmtp' %>
 filter   = postfix
 logpath  = /var/log/mail.log
 
@@ -224,7 +224,7 @@ logpath  = /var/log/mail.log
 [couriersmtp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "couriersmtp" %>
-port	 = smtp,ssmtp
+port     = <%= scope['::fail2ban::jail_ports'].key?('couriersmtp') ? scope['::fail2ban::jail_ports']['couriersmtp'] : 'smtp,ssmtp' %>
 filter   = couriersmtp
 logpath  = /var/log/mail.log
 
@@ -237,7 +237,7 @@ logpath  = /var/log/mail.log
 [courierauth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "courierauth" %>
-port	 = smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('courierauth') ? scope['::fail2ban::jail_ports']['courierauth'] : 'smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s' %>
 filter   = courierlogin
 logpath  = /var/log/mail.log
 
@@ -245,7 +245,7 @@ logpath  = /var/log/mail.log
 [sasl]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "sasl" %>
-port	 = smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('sasl') ? scope['::fail2ban::jail_ports']['sasl'] : 'smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s' %>
 filter   = sasl
 # You might consider monitoring /var/log/warn.log instead
 # if you are running postfix. See http://bugs.debian.org/507990
@@ -289,7 +289,7 @@ logpath  = /var/log/mail.log
 [named-refused-tcp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "named-refused-tcp" %>
-port     = domain,953
+port     = <%= scope['::fail2ban::jail_ports'].key?('named-refused-tcp') ? scope['::fail2ban::jail_ports']['named-refused-tcp'] : 'domain,953' %>
 protocol = tcp
 filter   = named-refused
 logpath  = /var/log/named/security.log

--- a/templates/trusty/etc/fail2ban/jail.conf.erb
+++ b/templates/trusty/etc/fail2ban/jail.conf.erb
@@ -130,7 +130,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 [ssh]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('ssh') ? scope['::fail2ban::jail_ports']['ssh'] : 'ssh' %>
 filter   = sshd
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -138,7 +138,7 @@ maxretry = 6
 [dropbear]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "dropbear" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('dropbear') ? scope['::fail2ban::jail_ports']['dropbear'] : 'ssh' %>
 filter   = dropbear
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -170,7 +170,7 @@ maxretry  = 2
 [ssh-ddos]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd-ddos') ? scope['::fail2ban::jail_ports']['sshd-ddos'] : 'ssh' %>
 filter   = sshd-ddos
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -195,7 +195,7 @@ maxretry = 6
 [ssh-iptables-ipset4]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-iptables-ipset4" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('ssh-iptables-ipset4') ? scope['::fail2ban::jail_ports']['ssh-iptables-ipset4'] : 'ssh' %>
 filter   = sshd
 banaction = iptables-ipset-proto4
 logpath  = /var/log/sshd.log
@@ -204,7 +204,7 @@ maxretry = 6
 [ssh-iptables-ipset6]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-iptables-ipset6" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('ssh-iptables-ipset6') ? scope['::fail2ban::jail_ports']['ssh-iptables-ipset6'] : 'ssh' %>
 filter   = sshd
 banaction = iptables-ipset-proto6
 logpath  = /var/log/sshd.log
@@ -218,7 +218,7 @@ maxretry = 6
 [apache]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache') ? scope['::fail2ban::jail_ports']['apache'] : 'http,https' %>
 filter   = apache-auth
 logpath  = /var/log/apache*/*error.log
 maxretry = 6
@@ -228,7 +228,7 @@ maxretry = 6
 [apache-multiport]
 
 enabled   = <%= scope['::fail2ban::jails'].include? "apache-multiport" %>
-port      = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-multiport') ? scope['::fail2ban::jail_ports']['apache-multiport'] : 'http,https' %>
 filter    = apache-auth
 logpath   = /var/log/apache*/*error.log
 maxretry  = 6
@@ -236,7 +236,7 @@ maxretry  = 6
 [apache-noscript]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-noscript') ? scope['::fail2ban::jail_ports']['apache-noscript'] : 'http,https' %>
 filter   = apache-noscript
 logpath  = /var/log/apache*/*error.log
 maxretry = 6
@@ -244,7 +244,7 @@ maxretry = 6
 [apache-overflows]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-overflows') ? scope['::fail2ban::jail_ports']['apache-overflows'] : 'http,https' %>
 filter   = apache-overflows
 logpath  = /var/log/apache*/*error.log
 maxretry = 2
@@ -256,7 +256,7 @@ maxretry = 2
 [php-url-fopen]
 
 enabled = <%= scope['::fail2ban::jails'].include? "php-url-fopen" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('php-url-fopen') ? scope['::fail2ban::jail_ports']['php-url-fopen'] : 'http,https' %>
 filter  = php-url-fopen
 logpath = /var/www/*/logs/access_log
 
@@ -269,7 +269,7 @@ logpath = /var/www/*/logs/access_log
 [lighttpd-fastcgi]
 
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-fastcgi" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('lighttpd-fastcgi') ? scope['::fail2ban::jail_ports']['lighttpd-fastcgi'] : 'http,https' %>
 filter  = lighttpd-fastcgi
 logpath = /var/log/lighttpd/error.log
 
@@ -279,7 +279,7 @@ logpath = /var/log/lighttpd/error.log
 [lighttpd-auth]
 
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('lighttpd-auth') ? scope['::fail2ban::jail_ports']['lighttpd-auth'] : 'http,https' %>
 filter  = suhosin
 logpath = /var/log/lighttpd/error.log
 
@@ -287,7 +287,7 @@ logpath = /var/log/lighttpd/error.log
 
 enabled = <%= scope['::fail2ban::jails'].include? "nginx-http-auth" %>
 filter  = nginx-http-auth
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('nginx-http-auth') ? scope['::fail2ban::jail_ports']['nginx-http-auth'] : 'http,https' %>
 logpath = /var/log/nginx/error.log
 
 # Monitor roundcube server
@@ -296,7 +296,7 @@ logpath = /var/log/nginx/error.log
 
 enabled  = <%= scope['::fail2ban::jails'].include? "roundcube-auth" %>
 filter   = roundcube-auth
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('roundcube-auth') ? scope['::fail2ban::jail_ports']['roundcube-auth'] : 'http,https' %>
 logpath  = /var/log/roundcube/userlogins
 
 
@@ -304,7 +304,7 @@ logpath  = /var/log/roundcube/userlogins
 
 enabled  = <%= scope['::fail2ban::jails'].include? "sogo-auth" %>
 filter   = sogo-auth
-port     = http, https
+port     = <%= scope['::fail2ban::jail_ports'].key?('sogo-auth') ? scope['::fail2ban::jail_ports']['sogo-auth'] : 'http,https' %>
 # without proxy this would be:
 # port    = 20000
 logpath  = /var/log/sogo/sogo.log
@@ -317,7 +317,7 @@ logpath  = /var/log/sogo/sogo.log
 [vsftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('vsftpd') ? scope['::fail2ban::jail_ports']['vsftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = vsftpd
 logpath  = /var/log/vsftpd.log
 # or overwrite it in jails.local to be
@@ -330,7 +330,7 @@ maxretry = 6
 [proftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "proftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('proftpd') ? scope['::fail2ban::jail_ports']['proftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = proftpd
 logpath  = /var/log/proftpd/proftpd.log
 maxretry = 6
@@ -339,7 +339,7 @@ maxretry = 6
 [pure-ftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('pure-ftpd') ? scope['::fail2ban::jail_ports']['pure-ftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = pure-ftpd
 logpath  = /var/log/syslog
 maxretry = 6
@@ -348,7 +348,7 @@ maxretry = 6
 [wuftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('wuftpd') ? scope['::fail2ban::jail_ports']['wuftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = wuftpd
 logpath  = /var/log/syslog
 maxretry = 6
@@ -361,7 +361,7 @@ maxretry = 6
 [postfix]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port     = smtp,ssmtp,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix') ? scope['::fail2ban::jail_ports']['postfix'] : 'smtp,ssmtp,submission' %>
 filter   = postfix
 logpath  = /var/log/mail.log
 
@@ -369,7 +369,7 @@ logpath  = /var/log/mail.log
 [couriersmtp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "couriersmtp" %>
-port     = smtp,ssmtp,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-smtp') ? scope['::fail2ban::jail_ports']['courier-smtp'] : 'smtp,ssmtp,submission' %>
 filter   = couriersmtp
 logpath  = /var/log/mail.log
 
@@ -382,7 +382,7 @@ logpath  = /var/log/mail.log
 [courierauth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "courierauth" %>
-port     = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('courierauth') ? scope['::fail2ban::jail_ports']['courierauth'] : 'smtp,ssmtp,submission,imap3,imaps,pop3,pop3s' %>
 filter   = courierlogin
 logpath  = /var/log/mail.log
 
@@ -390,7 +390,8 @@ logpath  = /var/log/mail.log
 [sasl]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "sasl" %>
-port     = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('sasl') ? scope['::fail2ban::jail_ports']['sasl'] : 'smtp,ssmtp,submission,imap3,imaps,pop3,pop3s' %>
+
 filter   = postfix-sasl
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
@@ -400,7 +401,7 @@ logpath  = /var/log/mail.log
 [dovecot]
 
 enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
-port    = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
+port    = <%= scope['::fail2ban::jail_ports'].key?('dovecot') ? scope['::fail2ban::jail_ports']['dovecot'] : 'pop3,pop3s,imap2,imap3,imaps,submission,smtp,ssmtp,sieve' %>
 filter  = dovecot
 logpath = /var/log/mail.log
 
@@ -411,7 +412,7 @@ logpath = /var/log/mail.log
 
 enabled  = <%= scope['::fail2ban::jails'].include? "mysqld-auth" %>
 filter   = mysqld-auth
-port     = 3306
+port     = <%= scope['::fail2ban::jail_ports'].key?('mysqld-auth') ? scope['::fail2ban::jail_ports']['mysqld-auth'] : '3306' %>
 logpath  = /var/log/mysqld.log
 
 
@@ -452,7 +453,7 @@ logpath  = /var/log/mysqld.log
 [named-refused-tcp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "named-refused-tcp" %>
-port     = domain,953
+port     = <%= scope['::fail2ban::jail_ports'].key?('named-refused-tcp') ? scope['::fail2ban::jail_ports']['named-refused-tcp'] : 'domain,953' %>
 protocol = tcp
 filter   = named-refused
 logpath  = /var/log/named/security.log
@@ -463,7 +464,7 @@ logpath  = /var/log/named/security.log
 
 enabled  = <%= scope['::fail2ban::jails'].include? "asterisk-tcp" %>
 filter   = asterisk
-port     = 5060,5061
+port     = port     = <%= scope['::fail2ban::jail_ports'].key?('asterisk-tcp') ? scope['::fail2ban::jail_ports']['asterisk-tcp'] : '5060,5061' %>
 protocol = tcp
 logpath  = /var/log/asterisk/messages
 
@@ -471,7 +472,7 @@ logpath  = /var/log/asterisk/messages
 
 enabled  = <%= scope['::fail2ban::jails'].include? "asterisk-udp" %>
 filter	 = asterisk
-port     = 5060,5061
+port     = port     = <%= scope['::fail2ban::jail_ports'].key?('asterisk-udp') ? scope['::fail2ban::jail_ports']['asterisk-udp'] : '5060,5061' %>
 protocol = udp
 logpath  = /var/log/asterisk/messages
 

--- a/templates/wheezy/etc/fail2ban/jail.conf.erb
+++ b/templates/wheezy/etc/fail2ban/jail.conf.erb
@@ -102,7 +102,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 [ssh]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('ssh') ? scope['::fail2ban::jail_ports']['ssh'] : 'ssh' %>
 filter   = sshd
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -110,7 +110,7 @@ maxretry = 6
 [dropbear]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "dropbear" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('dropbear') ? scope['::fail2ban::jail_ports']['dropbear'] : 'ssh' %>
 filter   = sshd
 logpath  = /var/log/dropbear
 maxretry = 6
@@ -142,7 +142,7 @@ maxretry  = 2
 [ssh-ddos]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
-port     = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('sshd-ddos') ? scope['::fail2ban::jail_ports']['sshd-ddos'] : 'ssh' %>
 filter   = sshd-ddos
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -154,7 +154,7 @@ maxretry = 6
 [apache]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache') ? scope['::fail2ban::jail_ports']['apache'] : 'http,https' %>
 filter   = apache-auth
 logpath  = /var/log/apache*/*error.log
 maxretry = 6
@@ -164,7 +164,7 @@ maxretry = 6
 [apache-multiport]
 
 enabled   = <%= scope['::fail2ban::jails'].include? "apache-multiport" %>
-port      = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-multiport') ? scope['::fail2ban::jail_ports']['apache-multiport'] : 'http,https' %>
 filter    = apache-auth
 logpath   = /var/log/apache*/*error.log
 maxretry  = 6
@@ -172,7 +172,7 @@ maxretry  = 6
 [apache-noscript]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-noscript') ? scope['::fail2ban::jail_ports']['apache-noscript'] : 'http,https' %>
 filter   = apache-noscript
 logpath  = /var/log/apache*/*error.log
 maxretry = 6
@@ -180,7 +180,7 @@ maxretry = 6
 [apache-overflows]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-overflows') ? scope['::fail2ban::jail_ports']['apache-overflows'] : 'http,https' %>
 filter   = apache-overflows
 logpath  = /var/log/apache*/*error.log
 maxretry = 2
@@ -192,7 +192,7 @@ maxretry = 2
 [vsftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('vsftpd') ? scope['::fail2ban::jail_ports']['vsftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = vsftpd
 logpath  = /var/log/vsftpd.log
 # or overwrite it in jails.local to be
@@ -205,7 +205,7 @@ maxretry = 6
 [proftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "proftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('proftpd') ? scope['::fail2ban::jail_ports']['proftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = proftpd
 logpath  = /var/log/proftpd/proftpd.log
 maxretry = 6
@@ -214,7 +214,7 @@ maxretry = 6
 [pure-ftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('pure-ftpd') ? scope['::fail2ban::jail_ports']['pure-ftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = pure-ftpd
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -223,7 +223,7 @@ maxretry = 6
 [wuftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('wuftpd') ? scope['::fail2ban::jail_ports']['wuftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 filter   = wuftpd
 logpath  = /var/log/auth.log
 maxretry = 6
@@ -236,7 +236,7 @@ maxretry = 6
 [postfix]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port     = smtp,ssmtp
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix') ? scope['::fail2ban::jail_ports']['postfix'] : 'smtp,ssmtp,submission' %>
 filter   = postfix
 logpath  = /var/log/mail.log
 
@@ -244,7 +244,7 @@ logpath  = /var/log/mail.log
 [couriersmtp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "couriersmtp" %>
-port     = smtp,ssmtp
+port     = <%= scope['::fail2ban::jail_ports'].key?('couriersmtp') ? scope['::fail2ban::jail_ports']['couriersmtp'] : 'smtp,ssmtp,submission' %>
 filter   = couriersmtp
 logpath  = /var/log/mail.log
 
@@ -257,7 +257,7 @@ logpath  = /var/log/mail.log
 [courierauth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "courierauth" %>
-port     = smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('courierauth') ? scope['::fail2ban::jail_ports']['courierauth'] : 'smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s' %>
 filter   = courierlogin
 logpath  = /var/log/mail.log
 
@@ -265,7 +265,7 @@ logpath  = /var/log/mail.log
 [sasl]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "sasl" %>
-port     = smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('sasl') ? scope['::fail2ban::jail_ports']['sasl'] : 'smtp,ssmtp,submission,imap3,imaps,pop3,pop3s' %>
 filter   = sasl
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
@@ -275,7 +275,7 @@ logpath  = /var/log/mail.log
 [dovecot]
 
 enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
-port    = smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s
+port    = <%= scope['::fail2ban::jail_ports'].key?('dovecot') ? scope['::fail2ban::jail_ports']['dovecot'] : 'pop3,pop3s,imap,imaps,submission,ssmtp,sieve' %>
 filter  = dovecot
 logpath = /var/log/mail.log
 
@@ -316,7 +316,7 @@ logpath = /var/log/mail.log
 [named-refused-tcp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "named-refused-tcp" %>
-port     = domain,953
+port     = <%= scope['::fail2ban::jail_ports'].key?('named-refused-tcp') ? scope['::fail2ban::jail_ports']['named-refused-tcp'] : 'domain,953' %>
 protocol = tcp
 filter   = named-refused
 logpath  = /var/log/named/security.log

--- a/templates/xenial/etc/fail2ban/jail.conf.erb
+++ b/templates/xenial/etc/fail2ban/jail.conf.erb
@@ -224,7 +224,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 [sshd]
 
 enabled = <%= scope['::fail2ban::jails'].include? "ssh" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('ssh') ? scope['::fail2ban::jail_ports']['ssh'] : 'ssh' %>
 logpath = %(sshd_log)s
 maxretry = 6
 
@@ -234,7 +234,7 @@ maxretry = 6
 # The mail-whois action send a notification e-mail with a whois request
 # in the body.
 enabled = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
-port    = ssh
+port    = <%= scope['::fail2ban::jail_ports'].key?('ssh-ddos') ? scope['::fail2ban::jail_ports']['ssh-ddos'] : 'ssh' %>
 logpath = %(sshd_log)s
 maxretry = 6
 
@@ -242,7 +242,7 @@ maxretry = 6
 [dropbear]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "dropbear" %>
-port     = ssh
+port     = <%= scope['::fail2ban::jail_ports'].key?('dropbear') ? scope['::fail2ban::jail_ports']['dropbear'] : 'ssh' %>
 logpath  = %(dropbear_log)s
 maxretry = 6
 
@@ -250,7 +250,7 @@ maxretry = 6
 [selinux-ssh]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "selinux-ssh" %>
-port     = ssh
+port     = <%= scope['::fail2ban::jail_ports'].key?('selinux-ssh') ? scope['::fail2ban::jail_ports']['selinux-ssh'] : 'ssh' %>
 logpath  = %(auditd_log)s
 maxretry = 5
 
@@ -262,7 +262,7 @@ maxretry = 5
 [apache-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-auth') ? scope['::fail2ban::jail_ports']['apache-auth'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 6
 
@@ -271,7 +271,7 @@ maxretry = 6
 # Ban hosts which agent identifies spammer robots crawling the web
 # for email addresses. The mail outputs are buffered.
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-badbots" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-badbots') ? scope['::fail2ban::jail_ports']['apache-badbots'] : 'http,https' %>
 logpath  = %(apache_access_log)s
 bantime  = 172800
 maxretry = 1
@@ -280,7 +280,7 @@ maxretry = 1
 [apache-noscript]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-noscript') ? scope['::fail2ban::jail_ports']['apache-noscript'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 6
 
@@ -288,7 +288,7 @@ maxretry = 6
 [apache-overflows]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-overflows') ? scope['::fail2ban::jail_ports']['apache-overflows'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
@@ -296,7 +296,7 @@ maxretry = 2
 [apache-nohome]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-nohome" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-nohome') ? scope['::fail2ban::jail_ports']['apache-nohome'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
@@ -304,7 +304,7 @@ maxretry = 2
 [apache-botsearch]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-botsearch" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-botsearch') ? scope['::fail2ban::jail_ports']['apache-botsearch'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
@@ -312,7 +312,7 @@ maxretry = 2
 [apache-fakegooglebot]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-fakegooglebot" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-fakegooglebot') ? scope['::fail2ban::jail_ports']['apache-fakegooglebot'] : 'http,https' %>
 logpath  = %(apache_access_log)s
 maxretry = 1
 ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
@@ -321,27 +321,27 @@ ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
 [apache-modsecurity]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-modsecurity" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-modsecurity') ? scope['::fail2ban::jail_ports']['apache-modsecurity'] : 'http,https' %>
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 [apache-shellshock]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-shellshock" %>
-port    = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('apache-shellshock') ? scope['::fail2ban::jail_ports']['apache-shellshock'] : 'http,https' %>
 logpath = %(apache_error_log)s
 maxretry = 1
 
 [nginx-http-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "nginx-http-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('nginx-http-auth') ? scope['::fail2ban::jail_ports']['nginx-http-auth'] : 'http,https' %>
 logpath = %(nginx_error_log)s
 
 [nginx-botsearch]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "nginx-botsearch" %>
-port     = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('nginx-botsearch') ? scope['::fail2ban::jail_ports']['nginx-botsearch'] : 'http,https' %>
 logpath  = %(nginx_error_log)s
 maxretry = 2
 
@@ -352,7 +352,7 @@ maxretry = 2
 [php-url-fopen]
 
 enabled = <%= scope['::fail2ban::jails'].include? "php-url-fopen" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('php-url-fopen') ? scope['::fail2ban::jail_ports']['php-url-fopen'] : 'http,https' %>
 logpath = %(nginx_access_log)s
           %(apache_access_log)s
 
@@ -360,7 +360,7 @@ logpath = %(nginx_access_log)s
 [suhosin]
 
 enabled = <%= scope['::fail2ban::jails'].include? "suhosin" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('suhosin') ? scope['::fail2ban::jail_ports']['suhosin'] : 'http,https' %>
 logpath = %(suhosin_log)s
 
 
@@ -368,7 +368,7 @@ logpath = %(suhosin_log)s
 # Same as above for Apache's mod_auth
 # It catches wrong authentifications
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('lighttpd-auth') ? scope['::fail2ban::jail_ports']['lighttpd-auth'] : 'http,https' %>
 logpath = %(lighttpd_error_log)s
 
 
@@ -379,28 +379,28 @@ logpath = %(lighttpd_error_log)s
 [roundcube-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "roundcube-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('roundcube-auth') ? scope['::fail2ban::jail_ports']['roundcube-auth'] : 'http,https' %>
 logpath  = %(roundcube_errors_log)s
 
 
 [openwebmail]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "openwebmail" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('openwebmail') ? scope['::fail2ban::jail_ports']['openwebmail'] : 'http,https' %>
 logpath  = /var/log/openwebmail.log
 
 
 [horde]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "horde" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('horde') ? scope['::fail2ban::jail_ports']['horde'] : 'http,https' %>
 logpath  = /var/log/horde/horde.log
 
 
 [groupoffice]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "groupoffice" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('groupoffice') ? scope['::fail2ban::jail_ports']['groupoffice'] : 'http,https' %>
 logpath  = /home/groupoffice/log/info.log
 
 
@@ -409,7 +409,7 @@ logpath  = /home/groupoffice/log/info.log
 enabled  = <%= scope['::fail2ban::jails'].include? "sogo-auth" %>
 # without proxy this would be:
 # port    = 20000
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('sogo-auth') ? scope['::fail2ban::jail_ports']['sogo-auth'] : 'http,https' %>
 logpath  = /var/log/sogo/sogo.log
 
 
@@ -417,7 +417,7 @@ logpath  = /var/log/sogo/sogo.log
 
 enabled  = <%= scope['::fail2ban::jails'].include? "tine20" %>
 logpath  = /var/log/tine20/tine20.log
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('tine20') ? scope['::fail2ban::jail_ports']['tine20'] : 'http,https' %>
 maxretry = 5
 
 
@@ -429,34 +429,34 @@ maxretry = 5
 [drupal-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "drupal-auth" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('drupal-auth') ? scope['::fail2ban::jail_ports']['drupal-auth'] : 'http,https' %>
 logpath  = %(syslog_daemon)s
 
 [guacamole]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "guacamole" %>
-port     = http,https
+port     = <%= scope['::fail2ban::jail_ports'].key?('guacamole') ? scope['::fail2ban::jail_ports']['guacamole'] : 'http,https' %>
 logpath  = /var/log/tomcat*/catalina.out
 
 [monit]
 #Ban clients brute-forcing the monit gui login
 enabled  = <%= scope['::fail2ban::jails'].include? "monit" %>
 filter   = monit
-port = 2812
+port = <%= scope['::fail2ban::jail_ports'].key?('monit') ? scope['::fail2ban::jail_ports']['monit'] : '2812' %>
 logpath  = /var/log/monit
 
 
 [webmin-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "webmin-auth" %>
-port    = 10000
+port    = <%= scope['::fail2ban::jail_ports'].key?('webmin-auth') ? scope['::fail2ban::jail_ports']['webmin-auth'] : '10000' %>
 logpath = %(syslog_authpriv)s
 
 
 [froxlor-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "froxlor-auth" %>
-port    = http,https
+port    = <%= scope['::fail2ban::jail_ports'].key?('froxlor-auth') ? scope['::fail2ban::jail_ports']['froxlor-auth'] : 'http,https' %>
 logpath  = %(syslog_authpriv)s
 
 
@@ -468,14 +468,14 @@ logpath  = %(syslog_authpriv)s
 [squid]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "squid" %>
-port     =  80,443,3128,8080
+port     = <%= scope['::fail2ban::jail_ports'].key?('squid') ? scope['::fail2ban::jail_ports']['squid'] : '80,443,3128,8080' %>
 logpath = /var/log/squid/access.log
 
 
 [3proxy]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "3proxy" %>
-port    = 3128
+port    = <%= scope['::fail2ban::jail_ports'].key?('3proxy') ? scope['::fail2ban::jail_ports']['3proxy'] : '3128' %>
 logpath = /var/log/3proxy.log
 
 
@@ -487,7 +487,7 @@ logpath = /var/log/3proxy.log
 [proftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "proftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('proftpd') ? scope['::fail2ban::jail_ports']['proftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(proftpd_log)s
 maxretry = 6
 
@@ -495,7 +495,7 @@ maxretry = 6
 [pure-ftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('pure-ftpd') ? scope['::fail2ban::jail_ports']['pure-ftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(pureftpd_log)s
 maxretry = 6
 
@@ -503,7 +503,7 @@ maxretry = 6
 [gssftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "gssftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('gssftpd') ? scope['::fail2ban::jail_ports']['gssftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(syslog_daemon)s
 maxretry = 6
 
@@ -511,7 +511,7 @@ maxretry = 6
 [wuftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('wuftpd') ? scope['::fail2ban::jail_ports']['wuftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(wuftpd_log)s
 maxretry = 6
 
@@ -522,7 +522,7 @@ maxretry = 6
 # if you want to rely on PAM failed login attempts
 # vsftpd's failregex should match both of those formats
 enabled  = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
+port     = <%= scope['::fail2ban::jail_ports'].key?('vsftpd') ? scope['::fail2ban::jail_ports']['vsftpd'] : 'ftp,ftp-data,ftps,ftps-data' %>
 logpath  = %(vsftpd_log)s
 maxretry = 6
 
@@ -535,28 +535,28 @@ maxretry = 6
 [assp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "assp" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('assp') ? scope['::fail2ban::jail_ports']['assp'] : 'smtp,465,submission' %>
 logpath  = /root/path/to/assp/logs/maillog.txt
 
 
 [courier-smtp]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "couriersmtp" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-smtp') ? scope['::fail2ban::jail_ports']['courier-smtp'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 
 
 [postfix]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix') ? scope['::fail2ban::jail_ports']['postfix'] : 'smtp,465,submission' %>
 logpath  = %(postfix_log)s
 
 
 [postfix-rbl]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix-rbl" %>
-port     = smtp,465,submission
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-rbl') ? scope['::fail2ban::jail_ports']['postfix-rbl'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 maxretry = 1
 
@@ -564,14 +564,14 @@ maxretry = 1
 [sendmail-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "sendmail-auth" %>
-port    = submission,465,smtp
+port    = <%= scope['::fail2ban::jail_ports'].key?('sendmail-auth') ? scope['::fail2ban::jail_ports']['sendmail-auth'] : 'smtp,465,submission' %>
 logpath = %(syslog_mail)s
 
 
 [sendmail-reject]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "sendmail-reject" %>
-port     = smtp,465,submission
+port    = <%= scope['::fail2ban::jail_ports'].key?('sendmail-reject') ? scope['::fail2ban::jail_ports']['sendmail-reject'] : 'smtp,465,submission' %>
 logpath  = %(syslog_mail)s
 
 
@@ -579,7 +579,7 @@ logpath  = %(syslog_mail)s
 
 enabled  = <%= scope['::fail2ban::jails'].include? "qmail-rbl" %>
 filter  = qmail
-port    = smtp,465,submission
+port    = <%= scope['::fail2ban::jail_ports'].key?('qmail-rbl') ? scope['::fail2ban::jail_ports']['qmail-rbl'] : 'smtp,465,submission' %>
 logpath = /service/qmail/log/main/current
 
 
@@ -588,42 +588,42 @@ logpath = /service/qmail/log/main/current
 [dovecot]
 
 enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
-port    = pop3,pop3s,imap,imaps,submission,465,sieve
+port    = <%= scope['::fail2ban::jail_ports'].key?('dovecot') ? scope['::fail2ban::jail_ports']['dovecot'] : 'pop3,pop3s,imap,imaps,submission,465,sieve' %>
 logpath = %(dovecot_log)s
 
 
 [sieve]
 
 enabled = <%= scope['::fail2ban::jails'].include? "sieve" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('sieve') ? scope['::fail2ban::jail_ports']['sieve'] : 'smtp,465,submission' %>
 logpath = %(dovecot_log)s
 
 
 [solid-pop3d]
 
 enabled = <%= scope['::fail2ban::jails'].include? "solid-pop3d" %>
-port    = pop3,pop3s
+port    = <%= scope['::fail2ban::jail_ports'].key?('solid-pop3d') ? scope['::fail2ban::jail_ports']['solid-pop3d'] : 'pop3,pop3s' %>
 logpath = %(solidpop3d_log)s
 
 
 [exim]
 
 enabled = <%= scope['::fail2ban::jails'].include? "exim" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('exim') ? scope['::fail2ban::jail_ports']['exim'] : 'smtp,465,submission' %>
 logpath = %(exim_main_log)s
 
 
 [exim-spam]
 
 enabled = <%= scope['::fail2ban::jails'].include? "exim-spam" %>
-port   = smtp,465,submission
+port   = <%= scope['::fail2ban::jail_ports'].key?('exim-spam') ? scope['::fail2ban::jail_ports']['exim-spam'] : 'smtp,465,submission' %>
 logpath = %(exim_main_log)s
 
 
 [kerio]
 
 enabled = <%= scope['::fail2ban::jails'].include? "kerio" %>
-port    = imap,smtp,imaps,465
+port    = <%= scope['::fail2ban::jail_ports'].key?('kerio') ? scope['::fail2ban::jail_ports']['kerio'] : 'imap,smtp,imaps,465' %>
 logpath = /opt/kerio/mailserver/store/logs/security.log
 
 
@@ -635,14 +635,14 @@ logpath = /opt/kerio/mailserver/store/logs/security.log
 [courier-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "courierauth" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('courier-auth') ? scope['::fail2ban::jail_ports']['courier-auth'] : 'smtp,465,submission,imap3,imaps,pop3,pop3s' %>
 logpath  = %(syslog_mail)s
 
 
 [postfix-sasl]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "sasl" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = <%= scope['::fail2ban::jail_ports'].key?('postfix-sasl') ? scope['::fail2ban::jail_ports']['postfix-sasl'] : 'smtp,465,submission,imap3,imaps,pop3,pop3s' %>
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
 # "warn" level but overall at the smaller filesize.
@@ -652,28 +652,28 @@ logpath  = %(postfix_log)s
 [perdition]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "perdition" %>
-port   = imap3,imaps,pop3,pop3s
+port   = <%= scope['::fail2ban::jail_ports'].key?('perdition') ? scope['::fail2ban::jail_ports']['perdition'] : 'imap3,imaps,pop3,pop3s' %>
 logpath = %(syslog_mail)s
 
 
 [squirrelmail]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "squirrelmail" %>
-port = smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks
+port = <%= scope['::fail2ban::jail_ports'].key?('squirrelmail') ? scope['::fail2ban::jail_ports']['squirrelmail'] : 'smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks' %>
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 
 [cyrus-imap]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "cyrus-imap" %>
-port   = imap3,imaps
+port   = <%= scope['::fail2ban::jail_ports'].key?('cyrus-imap') ? scope['::fail2ban::jail_ports']['cyrus-imap'] : 'imap3,imaps' %>
 logpath = %(syslog_mail)s
 
 
 [uwimap-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "uwimap-auth" %>
-port   = imap3,imaps
+port   = <%= scope['::fail2ban::jail_ports'].key?('uwimap-auth') ? scope['::fail2ban::jail_ports']['uwimap-auth'] : 'imap3,imaps' %>
 logpath = %(syslog_mail)s
 
 
@@ -706,14 +706,14 @@ logpath = %(syslog_mail)s
 [named-refused]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "named-refused" %>
-port     = domain,953
+port     = <%= scope['::fail2ban::jail_ports'].key?('named-refused') ? scope['::fail2ban::jail_ports']['named-refused'] : 'domain,953' %>
 logpath  = /var/log/named/security.log
 
 
 [nsd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "nsd" %>
-port     = 53
+port     = <%= scope['::fail2ban::jail_ports'].key?('nsd') ? scope['::fail2ban::jail_ports']['nsd'] : '53' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
 logpath = /var/log/nsd.log
@@ -726,7 +726,7 @@ logpath = /var/log/nsd.log
 [asterisk]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "asterisk" %>
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('asterisk') ? scope['::fail2ban::jail_ports']['asterisk'] : '5060,5061' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
@@ -737,7 +737,7 @@ maxretry = 10
 [freeswitch]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "freeswitch" %>
-port     = 5060,5061
+port     = <%= scope['::fail2ban::jail_ports'].key?('freeswitch') ? scope['::fail2ban::jail_ports']['freeswitch'] : '5060,5061' %>
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
@@ -759,7 +759,7 @@ maxretry = 10
 [mysqld-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "mysqld-auth" %>
-port     = 3306
+port     = <%= scope['::fail2ban::jail_ports'].key?('mysqld-auth') ? scope['::fail2ban::jail_ports']['mysqld-auth'] : '3306' %>
 logpath  = %(mysql_log)s
 maxretry = 5
 
@@ -809,7 +809,7 @@ logpath = /var/log/stunnel4/stunnel.log
 [ejabberd-auth]
 
 enabled = <%= scope['::fail2ban::jails'].include? "ejabberd-auth" %>
-port    = 5222
+port    = <%= scope['::fail2ban::jail_ports'].key?('ejabberd-auth') ? scope['::fail2ban::jail_ports']['ejabberd-auth'] : '5222' %>
 logpath = /var/log/ejabberd/ejabberd.log
 
 
@@ -818,7 +818,8 @@ logpath = /var/log/ejabberd/ejabberd.log
 enabled = <%= scope['::fail2ban::jails'].include? "counter-strike" %>
 logpath = /opt/cstrike/logs/L[0-9]*.log
 # Firewall: http://www.cstrike-planet.com/faq/6
-tcpport = 27030,27031,27032,27033,27034,27035,27036,27037,27038,27039
+# CAUTION: variable jail_ports would only ban TCP ports
+tcpport = <%= scope['::fail2ban::jail_ports'].key?('counter-strike') ? scope['::fail2ban::jail_ports']['counter-strike'] : '27030,27031,27032,27033,27034,27035,27036,27037,27038,27039' %>
 udpport = 1200,27000,27001,27002,27003,27004,27005,27006,27007,27008,27009,27010,27011,27012,27013,27014,27015
 action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
@@ -842,7 +843,7 @@ banaction = iptables-allports
 [directadmin]
 enabled = <%= scope['::fail2ban::jails'].include? "directadmin" %>
 logpath = /var/log/directadmin/login.log
-port = 2222
+port = <%= scope['::fail2ban::jail_ports'].key?('directadmin') ? scope['::fail2ban::jail_ports']['directadmin'] : '2222' %>
 
 [portsentry]
 enabled  = <%= scope['::fail2ban::jails'].include? "portsentry" %>
@@ -852,7 +853,7 @@ maxretry = 1
 [pass2allow-ftp]
 # this pass2allow example allows FTP traffic after successful HTTP authentication
 enabled  = <%= scope['::fail2ban::jails'].include? "pass2allow-ftp" %>
-port         = ftp,ftp-data,ftps,ftps-data
+port         = <%= scope['::fail2ban::jail_ports'].key?('pass2allow-ftp') ? scope['::fail2ban::jail_ports']['pass2allow-ftp'] : 'ftp,ftp-data,ftps,ftps-data' %>
 # knocking_url variable must be overridden to some secret value in filter.d/apache-pass.local
 filter       = apache-pass
 # access log of the website with HTTP auth


### PR DESCRIPTION
I added a hash parameter called jail_ports which lets you modify the ports being banned for the default jails. It's quite useful if you have a service running in a non-standard port (i.e., apache running on port 8080)